### PR TITLE
Add standard, policy, and guide templates

### DIFF
--- a/templates/template_guide.md
+++ b/templates/template_guide.md
@@ -10,8 +10,7 @@ date: "YYYY-MM-DD"
 author: "First Last"
 audience:
   - "[Primary audience, e.g. New team members / Platform engineers]"
-related_docs:
-  - ""
+related_docs: []
 revision_history:
   - version: "0.1"
     date: "YYYY-MM-DD"
@@ -128,11 +127,11 @@ _Brief paragraph: what this stage does and how it connects to the previous one._
 
 ### Steps
 
-4. _Do this._
+1. _Do this._
 
-5. _Do this._
+2. _Do this._
 
-6. _Verify: [Expected outcome.]_
+3. _Verify: [Expected outcome.]_
 
 ---
 
@@ -142,9 +141,9 @@ _Brief paragraph._
 
 ### Steps
 
-7. _Do this._
+1. _Do this._
 
-8. _Verify: [Expected outcome.]_
+2. _Verify: [Expected outcome.]_
 
 ---
 

--- a/templates/template_policy.md
+++ b/templates/template_policy.md
@@ -12,8 +12,7 @@ audience:
   - "Infrastructure Architecture"
   - "Operations"
   - "Security Architecture"
-related_docs:
-  - ""
+related_docs: []
 revision_history:
   - version: "0.1"
     date: "YYYY-MM-DD"

--- a/templates/template_standard.md
+++ b/templates/template_standard.md
@@ -12,8 +12,7 @@ audience:
   - "Infrastructure Architecture"
   - "Operations"
   - "Platform Engineering"
-related_docs:
-  - ""
+related_docs: []
 revision_history:
   - version: "0.1"
     date: "YYYY-MM-DD"


### PR DESCRIPTION
## Summary

- Adds `template_standard.md` — directive reference for mandatory technical requirements using SHALL/SHOULD/MAY convention
- Adds `template_policy.md` — concept-level governance artifact for organizational intent and accountability
- Adds `template_guide.md` — tutorial/onboarding walkthrough format

Completes P2 template backlog. Synced from architecture-docs.

## Test plan

- [ ] Verify all three templates render correctly with `docx-build`
- [ ] Confirm note blocks are present and clearly marked for deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)