### PR TITLE
Fix missing image constant import; add table keep-together page control

### DIFF
--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -445,13 +445,13 @@ def render_md_table(doc, table_data: dict) -> None:
     #      pass, causing Word to push the whole table to the next page if it
     #      does not fit in the remaining space. If the table exceeds a full
     #      page, Word breaks it normally (keepNext is advisory, not absolute).
-    all_rows   = list(table.rows)
+    all_rows   = table.rows
     n_rows     = len(all_rows)
     for r_idx, row in enumerate(all_rows):
         set_row_cant_split(row)
         is_last_row = (r_idx == n_rows - 1)
         for c_idx, cell in enumerate(row.cells):
-            is_last_cell = is_last_row and (c_idx == len(row.cells) - 1)
+            is_last_cell = is_last_row and (c_idx == n_cols - 1)
             if not is_last_cell:
                 for para in cell.paragraphs:
                     set_para_keep_next(para)

--- a/docx_builder/src/docx_builder/xml_helpers.py
+++ b/docx_builder/src/docx_builder/xml_helpers.py
@@ -11,7 +11,7 @@ Violating these orders causes Word to silently drop formatting or
 Summary of known constraints:
   - tcPr:  tcBorders must appear BEFORE w:shd
   - tblPr: tblBorders must appear BEFORE w:tblLook
-  - pPr:   w:keepNext must appear before w:pBdr, w:spacing, and w:ind
+  - pPr:   w:keepNext must appear after w:pStyle (when present) and before w:pBdr, w:spacing, and w:ind
   - pPr:   w:pBdr must appear before w:spacing and w:ind
   - pPr:   w:tabs must appear before w:spacing and w:ind
 
@@ -106,7 +106,7 @@ def set_col_width(table, col_idx: int, width_inches: float):
         row.cells[col_idx].width = Inches(width_inches)
 
 
-def set_row_cant_split(row) -> None:
+def set_row_cant_split(row: 'docx.table._Row') -> None:
     """
     Prevent a table row from breaking across pages.
 
@@ -121,19 +121,36 @@ def set_row_cant_split(row) -> None:
         trPr.append(cant_split)
 
 
-def set_para_keep_next(para) -> None:
+def set_para_keep_next(para: 'docx.text.paragraph.Paragraph') -> None:
     """
     Set <w:keepNext/> on a paragraph so Word keeps it on the same page as the
     following content.
 
-    In the OOXML pPr schema, keepNext appears before pBdr, spacing, and ind —
-    insert at index 0 to satisfy schema ordering. Idempotent: does nothing if
-    keepNext is already present.
+    In the OOXML pPr schema, keepNext appears after pStyle (when present) and
+    before pBdr, spacing, and ind. This function inserts keepNext in a
+    schema-compliant position and is idempotent: it does nothing if keepNext
+    is already present.
     """
     pPr = para._p.get_or_add_pPr()
     if pPr.find(qn('w:keepNext')) is None:
         keep_next = OxmlElement('w:keepNext')
-        pPr.insert(0, keep_next)
+        children  = list(pPr)
+        insert_pos = 0
+        # Place after w:pStyle if present (pStyle must be the first child).
+        for idx, child in enumerate(children):
+            if child.tag == qn('w:pStyle'):
+                insert_pos = idx + 1
+                break
+        else:
+            # No pStyle — place before the first of pBdr, spacing, or ind.
+            boundary_tags = {qn('w:pBdr'), qn('w:spacing'), qn('w:ind')}
+            for idx, child in enumerate(children):
+                if child.tag in boundary_tags:
+                    insert_pos = idx
+                    break
+            else:
+                insert_pos = len(children)
+        pPr.insert(insert_pos, keep_next)
 
 
 # ── Paragraph / run XML helpers ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Bug fix:** `DIAGRAM_DEFAULT_WIDTH_IN` was used in `markdown_parser.py` but never imported from `diagrams.py`, causing a `NameError` on any document that includes a referenced image (`![alt](path)`). Added the missing import.
- **Feature:** Tables now stay together on the page they start on (unless the table is too large to fit on one page, in which case Word breaks it normally).
  - `set_row_cant_split()` added to `xml_helpers.py` — sets `<w:cantSplit/>` in each row's `<w:trPr>`
  - `set_para_keep_next()` added to `xml_helpers.py` — sets `<w:keepNext/>` at correct `pPr` schema position
  - `render_md_table()` applies both after building all rows: `cantSplit` on every row + `keepNext` on all cell paragraphs except the last cell, chaining all rows through Word's keep-with-next layout pass

## Test plan

- [ ] Build a document that includes a `![alt](path)` image reference — should no longer raise `NameError`
- [ ] Build a document with a short table (< 1 page) — table should stay on the page it starts on; if it doesn't fit in remaining space, it should push to the next page intact
- [ ] Build a document with a long table (> 1 page) — table should break across pages normally (keepNext is advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)