### PR TITLE
Release: checkbox rendering, emoji font fix, heading numbering, CLAUDE.md updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,24 @@ docx-build examples/sample_input.md --org examples/org.yaml --output /tmp/test.d
 # Run tests
 cd docx_builder && python -m pytest tests/
 ```
+
+## Cross-Repo Tooling
+
+Repo management scripts live in a sibling repo:
+- Path: `../claude-repo-tools/scripts/`
+- Repo: https://github.com/KhalilGibrotha/claude-repo-tools
+
+Available commands:
+```bash
+# Cross-repo health check (branches, PRs, drift)
+bash ../claude-repo-tools/scripts/check-status.sh
+
+# Create release PR (develop → main) and optionally merge
+bash ../claude-repo-tools/scripts/release.sh dac-toolkit "Release message" --merge
+
+# Delete merged/orphaned branches
+bash ../claude-repo-tools/scripts/cleanup-branches.sh dac-toolkit
+
+# Build a DOCX and print heading tree for verification
+bash ../claude-repo-tools/scripts/verify-docx.sh <path-to-markdown-file>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,7 @@ bash ../claude-repo-tools/scripts/cleanup-branches.sh dac-toolkit
 
 # Build a DOCX and print heading tree for verification
 bash ../claude-repo-tools/scripts/verify-docx.sh <path-to-markdown-file>
+
+# Lint content repo markdown for LLM artifacts (run against the content repo, not dac-toolkit)
+bash ../claude-repo-tools/scripts/lint-markdown.sh architecture-docs
 ```

--- a/docx_builder/src/docx_builder/builder.py
+++ b/docx_builder/src/docx_builder/builder.py
@@ -128,6 +128,15 @@ def build_document(
     # in ![alt](path) references inside HtmlToDocx.
     md_src_dir = os.path.dirname(os.path.abspath(md_path))
 
+    # Step 1a: Normalize GFM task list checkboxes to Unicode box characters
+    #          before mistune sees them.  mistune does not process task lists,
+    #          so "- [ ] text" renders as literal "[ ] text" in the output.
+    #          Replace with ☐ / ☑ which Word renders correctly with standard fonts.
+    body_md = re.sub(r'^(\s*)-\s+\[x\]\s+', r'\1- ' + '\u2611 ',
+                     body_md, flags=re.MULTILINE | re.IGNORECASE)
+    body_md = re.sub(r'^(\s*)-\s+\[ \]\s+', r'\1- ' + '\u2610 ',
+                     body_md, flags=re.MULTILINE)
+
     # Step 1: Extract inline Mermaid fences before mistune sees them.
     #         Replaces each ```mermaid block with a __MERMAID_N__ placeholder.
     body_md_no_mermaid, mermaid_data_list = extract_mermaid_fences(body_md)

--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -57,6 +57,42 @@ def _strip_html(text: str) -> str:
     return re.sub(r'<[^>]+>', '', text or '').strip()
 
 
+# ── Emoji font splitter ───────────────────────────────────────────────────────
+#
+# Word cannot find emoji glyphs in Calibri or most body fonts.  When a run
+# contains emoji, the characters must be emitted with a font that has coverage —
+# on Windows, "Segoe UI Emoji" is the correct choice.
+#
+# _EMOJI_RE matches the Unicode ranges that cover the emoji used in this
+# document set (colored circles, check/cross marks, misc symbols).
+# _split_for_emoji splits a string into [(segment, is_emoji), ...] tuples so
+# _add_run can emit separate runs with the appropriate font per segment.
+
+_EMOJI_RE = re.compile(
+    '['
+    '\U0001F300-\U0001FAFF'   # Misc symbols, emoticons, supplemental (🔴🟡🟢✅❌ etc.)
+    '\u2600-\u27BF'            # Misc symbols + dingbats (⚠️ ⚪ ☑ ☐ etc.)
+    '\uFE00-\uFE0F'            # Variation selectors (emoji modifiers)
+    ']+',
+    re.UNICODE
+)
+
+def _split_for_emoji(text: str) -> list[tuple[str, bool]]:
+    """Split *text* into [(segment, is_emoji), ...] pairs."""
+    if not text:
+        return []
+    segments: list[tuple[str, bool]] = []
+    prev = 0
+    for m in _EMOJI_RE.finditer(text):
+        if m.start() > prev:
+            segments.append((text[prev:m.start()], False))
+        segments.append((m.group(), True))
+        prev = m.end()
+    if prev < len(text):
+        segments.append((text[prev:], False))
+    return segments or [(text, False)]
+
+
 # ── Inline markdown renderer for table cells ─────────────────────────────────
 #
 # Table cells are extracted before mistune sees them, so inline markdown
@@ -74,15 +110,23 @@ _INLINE_MD_RE = re.compile(
 
 
 def _add_cell_run(para, text, *, bold, italic, code, color, font_name, font_size):
-    """Add a single formatted run to a table-cell paragraph."""
+    """Add a single formatted run to a table-cell paragraph.
+
+    Emoji characters are split into separate runs with Segoe UI Emoji font so
+    Word can locate the glyphs.  Code spans are never split (no emoji expected).
+    """
     if not text:
         return
-    run            = para.add_run(text)
-    run.bold       = bold
-    run.italic     = italic
-    run.font.name  = "Courier New" if code else font_name
-    run.font.size  = font_size
-    set_run_color(run, color)
+    segments = [(text, False)] if code else _split_for_emoji(text)
+    for segment_text, is_emoji in segments:
+        if not segment_text:
+            continue
+        run           = para.add_run(segment_text)
+        run.bold      = bold
+        run.italic    = italic
+        run.font.name = "Courier New" if code else ("Segoe UI Emoji" if is_emoji else font_name)
+        run.font.size = font_size
+        set_run_color(run, color)
 
 
 def _render_cell_text(para, text, *, base_bold=False, color, font_name, font_size):
@@ -188,18 +232,24 @@ class HtmlToDocx(HTMLParser):
         if not text:
             return
         para = self._ensure_para()
-        run  = para.add_run(text)
-        run.font.name = "Courier New" if code else FONT_BODY
-        run.font.size = Pt(9) if code else Pt(10)
-        run.bold      = bold
-        run.italic    = italic
-        if link:
-            set_run_color(run, BLUE_LINK)
-            run.underline = True
-        elif code:
-            set_run_color(run, RGBColor(0x1F, 0x1F, 0x1F))
-        else:
-            set_run_color(run, BLACK)
+        # Split on emoji boundaries so emoji segments get Segoe UI Emoji font.
+        # Code spans are never emoji; skip splitting for them.
+        segments = [(text, False)] if code else _split_for_emoji(text)
+        for segment_text, is_emoji in segments:
+            if not segment_text:
+                continue
+            run           = para.add_run(segment_text)
+            run.font.name = "Courier New" if code else ("Segoe UI Emoji" if is_emoji else FONT_BODY)
+            run.font.size = Pt(9) if code else Pt(10)
+            run.bold      = bold
+            run.italic    = italic
+            if link:
+                set_run_color(run, BLUE_LINK)
+                run.underline = True
+            elif code:
+                set_run_color(run, RGBColor(0x1F, 0x1F, 0x1F))
+            else:
+                set_run_color(run, BLACK)
 
     def _handle_img(self, attrs_dict: dict) -> None:
         """


### PR DESCRIPTION
## Summary

- **Fix heading numbering reset after tables** (`builder.py`): The build loop was creating a new `HtmlToDocx` walker per text segment, resetting heading counters to 0 after every table or diagram. Walker is now created once before the loop so counters persist.
- **Fix checkbox rendering** (`builder.py`): `- [ ]` and `- [x]` task list syntax was passed to mistune as literal text. Now pre-processed to `☐` / `☑` (U+2610/2611) before rendering.
- **Fix emoji/status symbol rendering** (`markdown_parser.py`): Emoji characters (🔴🟡🟢⚪✅❌ etc.) were emitted with Calibri font, which has no emoji glyph coverage. Added `_split_for_emoji()` to split text at emoji code point boundaries and emit those runs with `Segoe UI Emoji` font. Applies to both body paragraphs and table cells.
- **CLAUDE.md**: Document `lint-markdown.sh` and cross-repo tooling scripts.

## Test plan

- [ ] Heading numbering is continuous across documents with multiple tables
- [ ] `- [ ]` renders as ☐ and `- [x]` renders as ☑ in DOCX output
- [ ] 🔴🟡🟢⚪✅ render as colored symbols in DOCX (not boxes or missing glyphs)
- [ ] Emoji in table cells also render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)