### PR TITLE
Fix h4–h6 headings rendering as unstyled body text

### DIFF
--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -17,14 +17,14 @@ Why the multi-stage approach:
   builder.py, so they appear in the correct document position.
 
 Supported markdown elements:
-  Block:  h1–h3, p, ul (unordered), ol (ordered), blockquote, pre/code, hr
+  Block:  h1–h6, p, ul (unordered), ol (ordered), blockquote, pre/code, hr
   Inline: strong, em, code, a (hyperlink text only, no live URL in DOCX)
   Images: ![alt text](relative/path/to/image.png) — resolved relative to
           the source .md file's directory (PNG, JPG, GIF, TIFF, BMP)
   Tables: GFM pipe tables with header / alignment divider / body rows
 
 Elements not supported (rendered as plain text or ignored):
-  - h4–h6 (treated as h3)
+  - h4–h6 styled as h3 (clamped — template defines three heading levels)
   - Nested blockquotes beyond one level
   - HTML inside markdown (stripped)
   - SVG images (export to PNG before referencing)
@@ -319,7 +319,7 @@ class HtmlToDocx(HTMLParser):
         if tag in self._skip_tags:
             return
 
-        if tag in ('h1', 'h2', 'h3'):
+        if tag in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
             self._flush_para()
             self._current_para = self.doc.add_paragraph()
 
@@ -374,9 +374,9 @@ class HtmlToDocx(HTMLParser):
         if self._tag_stack and self._tag_stack[-1][0] == tag:
             self._tag_stack.pop()
 
-        if tag in ('h1', 'h2', 'h3'):
+        if tag in ('h1', 'h2', 'h3', 'h4', 'h5', 'h6'):
             if self._current_para:
-                level    = int(tag[1])
+                level    = min(int(tag[1]), 3)   # clamp h4–h6 to h3 style
                 raw_text = ''.join(r.text for r in self._current_para.runs)
                 numbered = self._heading_numberer.format(level, raw_text)
                 # Replace paragraph content with the numbered heading text
@@ -440,6 +440,7 @@ class HtmlToDocx(HTMLParser):
 
         # Ignore whitespace-only text between block-level elements
         if data.strip() == '' and not (tags & {'p', 'li', 'h1', 'h2', 'h3',
+                                               'h4', 'h5', 'h6',
                                                'strong', 'em', 'code', 'a',
                                                'blockquote'}):
             return


### PR DESCRIPTION
## Summary

`h4`–`h6` tags were silently falling through the parser and rendering as plain unstyled body text — visually identical to normal paragraphs. The module docstring noted the intent ("h4–h6 treated as h3") but the code never implemented it.

## Root cause

Both `handle_starttag` and `handle_endtag` only checked for `('h1', 'h2', 'h3')`. `h4` tags skipped paragraph creation in starttag, then `handle_data` called `_ensure_para()` which created a plain paragraph with no heading style.

## Fix

Five targeted changes to `markdown_parser.py`:

| Location | Change |
|---|---|
| Module docstring (line 20) | `h1–h3` → `h1–h6` |
| Module docstring (line 27) | Clarified clamp behaviour |
| `handle_starttag` | Added `'h4', 'h5', 'h6'` to heading tag check |
| `handle_endtag` | Added `'h4', 'h5', 'h6'` to heading tag check |
| `handle_endtag` | `level = int(tag[1])` → `level = min(int(tag[1]), 3)` to clamp to Heading 3 style |
| `handle_data` whitespace guard | Added `'h4', 'h5', 'h6'` to inline tag set |

## Behaviour after fix

- `####`, `#####`, `######` headings render with Heading 3 style in DOCX output
- Auto-numbering applies at the h3 level (correct — template defines three heading levels)
- Whitespace handling inside deep headings is consistent with h1–h3

## Test plan

- [ ] Document with `####` heading renders with Heading 3 style, not plain body text
- [ ] Heading numbering is not disrupted by h4 presence
- [ ] h1/h2/h3 behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)