### PR TITLE
Self-contained toolchain image + build-context trim

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,34 @@
+# Keep the image build context to the toolkit itself. Excludes version-control
+# internals, embedded repo clones / test workspaces, virtualenvs, and caches
+# that are not part of the image (and that can bloat or break the context tar).
+
+# Version control and worktrees
+.git
+.worktrees
+
+# Embedded repo clones and local test workspaces (not part of the toolkit image)
+architecture-docs
+architecture-docs-starter
+ansible-devspaces
+ansible-devspaces-fresh
+
+# Virtualenvs
+.venv
+.venv-logo-test
+env
+
+# Caches and build artifacts
+__pycache__
+*.pyc
+*.egg-info
+.pytest_cache
+.mypy_cache
+.ruff_cache
+node_modules
+
+# Transient / OS
+/exports
+*.zip
+.tmp.driveupload
+.DS_Store
+Thumbs.db

--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -98,6 +98,22 @@ RUN pip install --no-cache-dir \
     "matplotlib>=3.8" \
     "pymupdf>=1.24"
 
+# ── Bake the toolkit itself into the image ───────────────────────────────────
+# The image carries docx_builder (installed) plus the scripts and the
+# presentations example, so a CONTENT repo consumes the image without cloning
+# the toolkit source. Build context is the repo root (see the build command in
+# the header and the docker-build workflow). docx_builder deps are already
+# installed above, so --no-deps keeps this offline. Scripts go on PATH; the
+# render scripts resolve their bundled example relative to /opt/dac-toolkit.
+COPY docx_builder /opt/dac-toolkit/docx_builder
+COPY scripts /opt/dac-toolkit/scripts
+COPY presentations /opt/dac-toolkit/presentations
+COPY diagrams /opt/dac-toolkit/diagrams
+RUN pip install --no-cache-dir --no-deps /opt/dac-toolkit/docx_builder \
+    && chmod -R g+rx /opt/dac-toolkit
+ENV DAC_TOOLKIT_HOME=/opt/dac-toolkit
+ENV PATH="/opt/dac-toolkit/scripts:${PATH}"
+
 # ── OpenShift arbitrary UID support ──────────────────────────────────────────
 # OpenShift runs containers with a random UID in the root group (GID 0).
 # All directories the process writes to must be group-writable.


### PR DESCRIPTION
Bakes docx_builder + scripts into the Dev Spaces image so content repos consume it without cloning the toolkit; adds .containerignore. Validated via the CI build (clean checkout). Enables the content-repo devfile pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)