### PR TITLE
Supply-chain hardening for the published image

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -5,7 +5,12 @@
 #   podman build -f .devcontainer/Dockerfile.devspaces -t <registry>/dac-toolkit:latest .
 #   podman push <registry>/dac-toolkit:latest
 #
-FROM registry.access.redhat.com/ubi9/python-312:latest
+# Base pinned by digest so a rebuild reproduces the same bytes. The digest is a
+# multi-arch manifest list, so multi-arch builds still work. The tag is recorded
+# for humans only; Dependabot bumps the digest (see .github/dependabot.yml), and
+# the CI vulnerability gate catches the base going stale between bumps.
+# Resolved from ubi9/python-312:latest on 2026-07-21.
+FROM registry.access.redhat.com/ubi9/python-312@sha256:cc8ec211f2e92279db55b1ee286b7eca55d9fb745fe4543a03d5868bfad0ba37
 
 USER 0
 
@@ -66,7 +71,8 @@ RUN curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QU
 
 # ── Mermaid CLI (mmdc) — installs Puppeteer + bundled Chromium ───────────────
 ENV PUPPETEER_CACHE_DIR=/opt/puppeteer-cache
-RUN npm install -g @mermaid-js/mermaid-cli \
+ARG MERMAID_CLI_VERSION=11.16.0
+RUN npm install -g "@mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}" \
     && npm cache clean --force \
     && chmod -R g+rx /opt/puppeteer-cache
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# The Dev Spaces image pins its UBI base by digest for reproducible builds.
+# Dependabot is what keeps that pin current — without it, a digest pin silently
+# becomes a stale base. Pair with the CI vulnerability gate in docker-build.yml.
+updates:
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(image)"
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,11 @@ on:
     paths:
       - '.devcontainer/Dockerfile.devspaces'
       - '.devcontainer/**'
+      - '.github/workflows/docker-build.yml'
   workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/khalilgibrotha/dac-toolkit
 
 jobs:
   build-and-push:
@@ -15,6 +19,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write        # cosign keyless signing + attestation OIDC
+      attestations: write    # actions/attest-*
 
     steps:
       - name: Checkout repository
@@ -27,15 +33,112 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      # Generates the OCI annotation set (source, revision, created, ...) so the
+      # image identifies itself instead of inheriting the UBI base's labels.
+      - name: Derive tags and OCI labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=dac-toolkit
+            org.opencontainers.image.description=Documentation-as-code toolchain (docx_builder, Quarto, Pandoc, Mermaid CLI, Vale) for OpenShift Dev Spaces
+            org.opencontainers.image.licenses=MIT
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build once into the local daemon so the scan gates publication rather
+      # than trailing it. The push below reuses this layer cache.
+      - name: Build for scanning
         uses: docker/build-push-action@v5
         with:
-          # Repo root, not .devcontainer/ — the Dockerfile copies
-          # .vale-bootstrap.ini from the repo root, matching the build
-          # command documented in Dockerfile.devspaces itself.
+          context: .
+          file: .devcontainer/Dockerfile.devspaces
+          load: true
+          push: false
+          tags: dac-toolkit:scan
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ignore-unfixed keeps the gate on things we can actually act on; an
+      # unfixable base CVE should not block every build.
+      - name: Vulnerability gate
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: dac-toolkit:scan
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
+      - name: Push image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
           context: .
           file: .devcontainer/Dockerfile.devspaces
           push: true
-          tags: |
-            ghcr.io/khalilgibrotha/dac-toolkit:latest
-            ghcr.io/khalilgibrotha/dac-toolkit:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless, GitHub OIDC)
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+
+      # The digest is what consumers should pin and what promotion copies.
+      - name: Publish digest to job summary
+        run: |
+          {
+            echo "### Published image"
+            echo
+            echo "Pin this digest in content-repo devfiles and promote by it:"
+            echo
+            echo '```'
+            echo "${IMAGE}@${DIGEST}"
+            echo '```'
+            echo
+            echo "Verify signature:"
+            echo
+            echo '```bash'
+            echo "cosign verify ${IMAGE}@${DIGEST} \\"
+            echo "  --certificate-identity-regexp '^https://github.com/${GITHUB_REPOSITORY}/' \\"
+            echo "  --certificate-oidc-issuer https://token.actions.githubusercontent.com"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+          DIGEST: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Addresses #35.

**Provenance:** the image previously carried only the UBI base's labels — it identified itself as Red Hat's `python-312` image and its `org.opencontainers.image.revision` pointed at the *base image's* commit. Nothing tied it to this repo. Now generated via `docker/metadata-action`.

**Reproducibility:** UBI base pinned by digest (multi-arch manifest list, so multi-arch still works), `mermaid-cli` pinned (the last unpinned tool), and Dependabot added for docker + actions so the pin stays current instead of silently going stale.

**Evidence:** Trivy gate on HIGH/CRITICAL run against a locally loaded build so the scan gates publication rather than trailing it; SLSA build-provenance and SPDX SBOM attestations pushed to the registry; keyless cosign signing via GitHub OIDC. The job summary prints the digest to pin and the `cosign verify` command.

Requires `id-token: write` and `attestations: write` permissions, both added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)