### PR TITLE
Release: fix trivy-action reference

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -68,7 +68,7 @@ jobs:
       # ignore-unfixed keeps the gate on things we can actually act on; an
       # unfixable base CVE should not block every build.
       - name: Vulnerability gate
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: dac-toolkit:scan
           format: table


### PR DESCRIPTION
Unblocks the hardened image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)