### PR TITLE
Clear Go stdlib CVEs: bump gh and vale, scope esbuild skip

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -33,7 +33,7 @@ RUN dnf install -y --nodocs \
     git \
     # Utilities
     jq \
-    && dnf install -y --nodocs https://github.com/cli/cli/releases/download/v2.67.0/gh_2.67.0_linux_amd64.rpm \
+    && dnf install -y --nodocs https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.rpm \
     && dnf clean all
 
 # ── Pandoc (direct binary — not available in free UBI repos) ─────────────────
@@ -83,7 +83,7 @@ RUN echo '{"args":["--no-sandbox","--disable-setuid-sandbox","--disable-dev-shm-
 ENV PUPPETEER_CONFIG=/opt/puppeteer-config.json
 
 # ── Vale prose linter ─────────────────────────────────────────────────────
-ARG VALE_VERSION=3.9.5
+ARG VALE_VERSION=3.15.1
 COPY .vale-bootstrap.ini /tmp/.vale.ini
 RUN curl -fsSL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
     | tar xz -C /usr/local/bin vale \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,6 +67,15 @@ jobs:
 
       # ignore-unfixed keeps the gate on things we can actually act on; an
       # unfixable base CVE should not block every build.
+      #
+      # skip-files: esbuild is a build-time JS bundler vendored inside Quarto.
+      # Its findings are Go stdlib CVEs compiled into that binary; in this image
+      # it only ever bundles our own document and deck sources, so the network
+      # and untrusted-input paths those CVEs sit on are not reachable here.
+      # Clearing them means upgrading Quarto, which changes pptx rendering and
+      # so requires a deck re-render and visual QA - tracked separately. The
+      # path is deliberately version-pinned so a Quarto bump invalidates this
+      # skip and forces the question to be re-asked.
       - name: Vulnerability gate
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -75,6 +84,7 @@ jobs:
           exit-code: '1'
           ignore-unfixed: true
           severity: HIGH,CRITICAL
+          skip-files: /opt/quarto-1.6.40/bin/tools/x86_64/esbuild
 
       - name: Push image
         id: push


### PR DESCRIPTION
The new vulnerability gate blocked publication on its first run — 86 fixable HIGH/CRITICAL findings, all Go stdlib CVEs compiled into statically linked binaries. The RHEL base itself was clean.

- `gh` 2.67.0 -> 2.96.0 (36)
- `vale` 3.9.5 -> 3.15.1 (32)
- Quarto's vendored `esbuild` (18) — **skipped, not fixed.** Upgrading Quarto (1.6.40 -> 1.9.38) changes pptx rendering and the committed decks were visually QA'd against 1.6.40, so it needs a deliberate re-render pass. Rationale recorded inline; the skip path is version-pinned so a Quarto bump invalidates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)