### PR TITLE
Mirror source tree under exports/; make build scope configurable

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -53,15 +53,16 @@ build_one() {
     return
   fi
 
+  # Mirror the source tree under exports/ rather than flattening it into the
+  # filename. This keeps the published set copyable as a folder: the structure
+  # matches the repo, and re-copying updates files in place instead of leaving
+  # renamed duplicates behind.
   local rel_path="${md_file#"$CONTENT_DIR"/}"
-  local base
-  base=$(basename "$md_file" .md)
-  local dir_name
-  dir_name=$(dirname "$rel_path" | tr '/' '_')
-  local out_name="${dir_name}_${base}.docx"
-  local out_path="$EXPORTS/$out_name"
+  local out_rel="${rel_path%.md}.docx"
+  local out_path="$EXPORTS/$out_rel"
 
-  echo "  Building: $rel_path -> exports/$out_name"
+  mkdir -p "$(dirname "$out_path")"
+  echo "  Building: $rel_path -> exports/$out_rel"
   docx-build "$md_file" "${logo_args[@]}" "${org_args[@]}" --output "$out_path"
   built=$((built + 1))
 }
@@ -70,17 +71,28 @@ if [[ $# -gt 0 ]]; then
   # Build a specific file
   build_one "$1"
 else
-  # Build all content Markdown files (skip READMEs)
-  while IFS= read -r -d '' md_file; do
-    build_one "$md_file"
-  done < <(find \
-    "$CONTENT_DIR/docs" \
-    "$CONTENT_DIR/initiatives" \
-    "$CONTENT_DIR/patterns" \
-    "$CONTENT_DIR/governance" \
-    "$CONTENT_DIR/decisions" \
-    -name '*.md' -not -name 'README.md' -not -path '*/.git/*' \
-    -print0 2>/dev/null)
+  # Which top-level directories carry publishable content is a property of the
+  # content repo, not of this engine. Override with DAC_DOC_DIRS (space
+  # separated) to publish a different set without editing the toolkit.
+  # Directories that do not exist are skipped silently.
+  DOC_DIRS="${DAC_DOC_DIRS:-docs initiatives patterns governance decisions references}"
+
+  search_dirs=()
+  for d in $DOC_DIRS; do
+    [[ -d "$CONTENT_DIR/$d" ]] && search_dirs+=("$CONTENT_DIR/$d")
+  done
+
+  if [[ ${#search_dirs[@]} -eq 0 ]]; then
+    echo "  No content directories found under $CONTENT_DIR (looked for: $DOC_DIRS)"
+  else
+    # Build all content Markdown files (skip READMEs and archived material)
+    while IFS= read -r -d '' md_file; do
+      build_one "$md_file"
+    done < <(find "${search_dirs[@]}" \
+      -name '*.md' -not -name 'README.md' \
+      -not -path '*/.git/*' -not -path '*/archive/*' \
+      -print0 2>/dev/null)
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
Exports were flattened into the filename, so the published set could not be synced as a folder — a re-upload created renamed duplicates instead of updating in place.

**Output now mirrors the source tree**, which makes `exports/` copyable to a document library where files update in place.

**Also removes org-specific structure from the engine.** The publishable directory list was hardcoded in the toolkit; it is now `DAC_DOC_DIRS` (space-separated, overridable), defaulting to the previous set plus `references/`. Archived material excluded by default.

Verified against the real content repo: 88 documents selected (100 total, less 9 working notes and 3 archived).

🤖 Generated with [Claude Code](https://claude.com/claude-code)