### PR TITLE
Rebuild image when baked content changes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,15 @@ on:
     branches:
       - main
     paths:
-      - '.devcontainer/Dockerfile.devspaces'
+      # Everything the image bakes in. scripts/, docx_builder/, presentations/
+      # and diagrams/ are COPYied into /opt/dac-toolkit, so a change to any of
+      # them must republish - watching only .devcontainer/ meant script fixes
+      # silently never reached the image.
       - '.devcontainer/**'
+      - 'scripts/**'
+      - 'docx_builder/**'
+      - 'presentations/**'
+      - 'diagrams/**'
       - '.github/workflows/docker-build.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
The Dockerfile bakes `scripts/`, `docx_builder/`, `presentations/` and `diagrams/` into `/opt/dac-toolkit`, but the build only triggered on `.devcontainer/**`.

So the hierarchical-exports fix to `build-docs.sh` merged to main and **never reached the published image** — the workspace silently kept running the old script. Caught when no build fired after that merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)