### PR TITLE
Add mirror layout to docx-build-all; fix two latent bugs

### DIFF
--- a/docx_builder/src/docx_builder/batch_cli.py
+++ b/docx_builder/src/docx_builder/batch_cli.py
@@ -50,7 +50,29 @@ def _load_org_yaml(path: str) -> dict:
     return data.get('org', data)
 
 
+def _force_utf8_console() -> None:
+    """
+    Make stdout/stderr tolerate non-ASCII.
+
+    Windows consoles default to a legacy code page (cp1252) that cannot encode
+    characters which legitimately appear in document titles, file paths, and in
+    this tool's own progress output. Without this, printing the line that
+    reports a *successful* render raises UnicodeEncodeError, the surrounding
+    except block catches it, and the document is reported as FAILED and written
+    to the render index as an error - despite the DOCX having been produced
+    correctly. Replace rather than fail: a mangled character in a console
+    message is never worth losing a build over.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8', errors='replace')
+        except (AttributeError, OSError, ValueError):
+            pass    # not a reconfigurable stream (redirected, or older Python)
+
+
 def main():
+    _force_utf8_console()
+
     parser = argparse.ArgumentParser(
         prog="docx-build-all",
         description="Batch render Markdown documentation to DOCX.",
@@ -184,7 +206,17 @@ parent directory. See the dac-toolkit README for the config schema.
             print(f"SKIP     {doc.rel_path}")
             continue
 
-        # MOVED — remove old output before rendering to new location
+        # Resolve the new output path FIRST, so we can tell whether the previous
+        # output is genuinely superseded. Under the 'mirror' layout a status
+        # change does not move the file, so removing before resolving would
+        # delete the very file about to be written — and lose it outright if the
+        # render then failed.
+        output_path = resolve_output_path(
+            config.export_root, doc.path, doc.status, doc.version,
+            layout=config.layout, content_root=config.config_dir,
+        )
+
+        # MOVED — remove the superseded output, but only if it is elsewhere
         old_output_abs = None
         old_status     = None
         if outcome == RenderIndex.OUTCOME_MOVED and existing:
@@ -192,14 +224,10 @@ parent directory. See the dac-toolkit README for the config schema.
             # Index stores paths relative to config_dir; resolve to absolute
             old_output_abs = os.path.join(config.config_dir, existing.output) \
                 if not os.path.isabs(existing.output) else existing.output
-            warn = remove_old_output(old_output_abs, doc.rel_path)
-            if warn:
-                result_warnings.append(warn)
-
-        # Resolve output path
-        output_path = resolve_output_path(
-            config.export_root, doc.path, doc.status, doc.version
-        )
+            if os.path.normpath(old_output_abs) != os.path.normpath(output_path):
+                warn = remove_old_output(old_output_abs, doc.rel_path)
+                if warn:
+                    result_warnings.append(warn)
 
         # Render
         try:

--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -8,6 +8,7 @@ Config schema (docx-build.yml):
 
     export_root: exports/          # required — root folder for DOCX output
     org: vars/org.yaml             # optional — org identity YAML (same as --org flag)
+    layout: status                 # optional — 'status' (default) or 'mirror'
 
     scan:                          # required — at least one entry
       - docs/
@@ -25,6 +26,20 @@ Config schema (docx-build.yml):
       skip_informational: false    # default: false — render status: Informational docs
 
 Paths in scan and exclude are resolved relative to the config file's directory.
+
+Layout
+──────
+    status  (default)  exports/<Status>/<name>_v<version>.docx
+                       Groups by review state. Good when the export set is read
+                       as "what is accepted vs still in draft".
+
+    mirror             exports/<source path>/<name>.docx
+                       Reproduces the source tree, with no status folder and no
+                       version in the filename. Use this when the export set is
+                       synced to a document library as a folder: paths stay
+                       stable across status changes and version bumps, so a
+                       re-upload updates files in place instead of leaving
+                       renamed or relocated duplicates behind.
 """
 
 import os
@@ -53,6 +68,10 @@ class BatchOptions:
     skip_informational: bool = False
 
 
+LAYOUTS = ('status', 'mirror')
+DEFAULT_LAYOUT = 'status'
+
+
 @dataclass
 class BatchConfig:
     export_root: str          # resolved absolute path
@@ -62,6 +81,7 @@ class BatchConfig:
     options: BatchOptions
     config_path: str          # absolute path to the config file itself
     config_dir: str           # directory containing the config file
+    layout: str = DEFAULT_LAYOUT   # 'status' or 'mirror'
 
 
 def find_config(start_dir: str, filename: str = "docx-build.yml") -> Optional[str]:
@@ -155,6 +175,13 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
     else:
         org = None
 
+    layout = str(raw.get('layout') or DEFAULT_LAYOUT).strip().lower()
+    if layout not in LAYOUTS:
+        raise ConfigError(
+            f"Invalid config file: {path}\n"
+            f"  - 'layout' must be one of {', '.join(LAYOUTS)} (got: {layout!r})"
+        )
+
     raw_opts = raw.get('options') or {}
     options = BatchOptions(
         skip_retired=_parse_bool(raw_opts.get('skip_retired', True)),
@@ -169,4 +196,5 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         options=options,
         config_path=path,
         config_dir=config_dir,
+        layout=layout,
     )

--- a/docx_builder/src/docx_builder/batch_output.py
+++ b/docx_builder/src/docx_builder/batch_output.py
@@ -1,5 +1,19 @@
 """
-batch_output.py — Status-based output folder management and file naming.
+batch_output.py — Output folder management and file naming.
+
+Two layouts are supported, selected by the 'layout' key in docx-build.yml.
+
+    status  (default)  exports/<Status>/<name>_v<version>.docx
+                       Groups by review state; the path encodes status and
+                       version, so both change as a document progresses.
+
+    mirror             exports/<source path>/<name>.docx
+                       Reproduces the source tree. No status folder, no version
+                       suffix - the path is stable across promotions and version
+                       bumps, so syncing the export folder to a document library
+                       updates files in place instead of leaving duplicates.
+
+The rest of this docstring describes the 'status' layout.
 
 Rendered DOCX files are organised into subfolders of export_root by document
 status. When a document's status changes between renders, the old file is
@@ -53,24 +67,55 @@ def status_to_folder(status: str) -> str:
     return status.replace(' ', '-')
 
 
-def resolve_output_path(export_root: str, md_path: str, status: str, version: str) -> str:
+def resolve_output_path(
+    export_root: str,
+    md_path: str,
+    status: str,
+    version: str,
+    layout: str = 'status',
+    content_root: Optional[str] = None,
+) -> str:
     """
     Compute the full output path for a rendered DOCX.
 
     Args:
-        export_root: absolute path to the export root directory.
-        md_path:     absolute path to the source .md file.
-        status:      document status (used for subfolder selection).
-        version:     document version (appended to filename).
+        export_root:  absolute path to the export root directory.
+        md_path:      absolute path to the source .md file.
+        status:       document status (subfolder selection in 'status' layout).
+        version:      document version (filename suffix in 'status' layout).
+        layout:       'status' (default) or 'mirror'. See module docstring.
+        content_root: repo root the source tree is relative to. Required for
+                      'mirror'; unused by 'status'.
 
     Returns:
-        Absolute path where the DOCX should be saved, e.g.:
-        /repo/exports/Draft/overview_aap_architecture_v0.3.docx
+        Absolute path where the DOCX should be saved, e.g.
+        status: /repo/exports/Draft/overview_aap_architecture_v0.3.docx
+        mirror: /repo/exports/initiatives/aap/overview_aap_architecture.docx
+
+    Raises:
+        ValueError: unknown layout, or 'mirror' without content_root.
     """
     stem = os.path.splitext(os.path.basename(md_path))[0]
-    folder = os.path.join(export_root, status_to_folder(status))
-    filename = f"{stem}_v{version}.docx"
-    return os.path.join(folder, filename)
+
+    if layout == 'status':
+        folder = os.path.join(export_root, status_to_folder(status))
+        return os.path.join(folder, f"{stem}_v{version}.docx")
+
+    if layout != 'mirror':
+        raise ValueError(f"unknown layout: {layout!r}")
+    if not content_root:
+        raise ValueError("layout 'mirror' requires content_root")
+
+    # Mirror deliberately omits both the status folder and the version suffix.
+    # The point of this layout is a path that does NOT change when a document is
+    # promoted or revised, so that syncing the export folder updates files in
+    # place rather than accumulating relocated or renamed duplicates.
+    rel_dir = os.path.relpath(os.path.dirname(md_path), content_root)
+    if rel_dir == os.curdir or rel_dir.startswith(os.pardir):
+        # Source sits at, or outside, the content root. Fall back to flat rather
+        # than writing outside export_root.
+        rel_dir = ''
+    return os.path.join(export_root, rel_dir, f"{stem}.docx")
 
 
 def ensure_output_dir(output_path: str) -> None:

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -18,6 +18,12 @@ shift 2>/dev/null || true
 # Which top-level directories carry publishable content is a property of the
 # content repo, not of this engine. Override with DAC_DOC_DIRS (space separated)
 # to publish a different set without editing the toolkit.
+#
+# NOTE: docx-build-all is the newer batch path. It reads the same set from the
+# 'scan' key of docx-build.yml and additionally supports exclusions, status
+# filtering, an incremental render index, and both output layouts. This default
+# is kept identical to the documented scan list so the two cannot disagree about
+# what gets published. If you change one, change the other.
 DOC_DIRS="${DAC_DOC_DIRS:-docs initiatives patterns governance decisions references}"
 
 has_content() {


### PR DESCRIPTION
`docx-build-all` wrote only `exports/<Status>/<name>_v<version>.docx`. That path encodes status **and** version, so promoting or revising a document moves or renames its output — which defeats folder-syncing `exports/` to a document library.

**Adds `layout: mirror | status`**, defaulting to `status` so nothing existing changes. Mirror reproduces the source tree with no status folder and no version suffix, so the path is stable across promotions and version bumps.

## Two bugs found while testing

1. **Delete-before-resolve.** Superseded output was removed before the new path was computed. Under mirror a status change doesn't move the file — so it deleted the file it was about to write, and would lose it outright if the render then failed. Now resolves first, removes only if genuinely different.
2. **Windows misreported successes as failures.** Printing the success line raised `UnicodeEncodeError` on `→` against the cp1252 console; the except block then recorded a correctly-rendered document as FAILED, in both the report and the render index. stdout/stderr now reconfigured to UTF-8 with `errors='replace'`.

Verified end-to-end: **3 rendered / 0 failed**, previously 3 rendered / 3 falsely failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)