### PR TITLE
Logo support in docx-build-all, cover fallback org fix, dual selection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Documentation-as-Code toolkit that converts Markdown with YAML front matter into
 styled DOCX documents with cover pages, table of contents, revision history,
-auto-numbered headings, and embedded Mermaid diagrams.
+auto-numbered headings, and embedded diagrams (Mermaid plus any
+Kroki-supported language — PlantUML, Graphviz, D2, and more).
 
 ---
 
@@ -103,19 +104,103 @@ content-repo/
 └── exports/        Generated DOCX output
 ```
 
-### Build all documents in a content repo
+## Choosing What Gets Rendered
 
-```bash
-bash scripts/build-docs.sh /path/to/content-repo
+The toolkit supports two first-class ways to select which documents get
+rendered, plus the original shell pipeline. All three are supported — none is
+deprecated. Pick the one that matches how your repo decides what is
+publishable.
+
+| Approach | In one sentence |
+|---|---|
+| **Scan** — `docx-build-all` + `docx-build.yml` | Renders everything under the configured `scan:` folders, minus `exclude:` paths and status filters. |
+| **Manifest** — `scripts/docx_manifest.py` + `manifests/render-manifest.yaml` | Renders exactly the documents listed in the manifest, nothing else. |
+| **Shell pipeline** — `scripts/build-docs.sh` | The original path: pre-renders diagrams, then builds every front-mattered Markdown file under the conventional content folders. No config file required. |
+
+### When to choose which
+
+**Choose scan** when the repo's working set *is* the publication set: everything
+under `docs/`, `governance/`, etc. should ship, and the interesting decisions
+are which folders are in scope and which statuses to hold back. Its incremental
+render index and `mirror` layout make it the right fit for repeatedly syncing
+`exports/` to a document library as a folder.
+
+**Choose manifest** when publication is curated: a deliberate subset of the
+repo ships, and the explicit list is itself the governance artifact — a
+reviewable, diffable record of what the org has agreed to publish. Also the
+right fit when documents need per-document org/logo/output overrides, or when
+pre-rendered diagram PNGs should be committed as reviewable assets (the
+manifest wrapper rewrites fences to PNG files before the build; the builder
+itself also renders any Kroki-supported fence inline on every path).
+
+**Choose the shell pipeline** when you want zero configuration: point
+`build-docs.sh` at a content repo shaped like the layout above and it builds
+everything with front matter. It remains fully supported.
+
+### Capability comparison
+
+| Capability | `build-docs.sh` (shell) | `docx-build-all` (scan) | `docx_manifest.py` (manifest) |
+|---|---|---|---|
+| Selection model | Conventional folders (override via `DAC_DOC_DIRS`) | `scan:` + `exclude:` in `docx-build.yml` | Explicit `documents:` list in `render-manifest.yaml` |
+| Config required | None | `docx-build.yml` | `manifests/render-manifest.yaml` |
+| Output layout | Mirrors source tree under `exports/` | `status` (grouped by review state) or `mirror` | Mirrors source tree under `exports/` (per-document `output:` override) |
+| Incremental rebuild | No — always rebuilds | Yes — render index skips unchanged version/status | No — always rebuilds |
+| Status filtering | No | `skip_retired`, `skip_informational` | No — the list is the filter |
+| Diagram handling | Pre-renders Mermaid sources, then the builder handles inline fences | Builder handles inline fences for any Kroki-supported language | Rewrites any Kroki-supported fence (Mermaid, PlantUML, Graphviz, D2, ...) to PNG via a Kroki service, then calls `docx-build` |
+| Logo | Auto-detects `assets/logo/logo.png` | `logo:` key, `--logo` flag, or auto-detects `assets/logo/logo.png` | Per-document `logo:` key, or auto-detects `assets/logo/logo.png` |
+| Org identity | Auto-detects `vars/org.yaml` | `org:` key, `--org` flag, or front matter | Per-document `org:` key, or auto-detects `vars/org.yaml` |
+| Environment | Needs `docx-build` on PATH | Needs `docx-build-all` on PATH | Bootstraps its own `.venv-docx-render/` |
+
+### Scan: build all documents with docx-build-all
+
+Create `docx-build.yml` at the content repo root:
+
+```yaml
+export_root: exports/          # required — root folder for DOCX output
+org: vars/org.yaml             # optional — org identity YAML (same as --org flag)
+logo: assets/logo/logo.png     # optional — cover logo; auto-detected at this path if omitted
+layout: mirror                 # optional — 'status' (default) or 'mirror'
+
+scan:                          # required — folders to render
+  - docs/
+  - governance/
+  - references/
+
+exclude:                       # optional — paths to skip even if under scan
+  - templates/
+  - archive/
+
+options:                       # optional
+  skip_retired: true           # default: true
+  skip_informational: false    # default: false
 ```
 
-The script auto-detects `vars/org.yaml` and `assets/logo/logo.png` in the
-content directory and passes them to `docx-build`.
+Then run it from anywhere inside the repo (it searches upward for the config):
 
-### Build manifest-managed documents from the content repo root
+```bash
+docx-build-all                 # render changed documents
+docx-build-all --dry-run       # report what would render, write nothing
+docx-build-all --force         # re-render everything
+```
 
-When a content repo includes `manifests/render-manifest.yaml`, run the toolkit
-wrapper from the content repo root:
+Paths in the config are resolved relative to the config file's directory.
+`--org` and `--logo` flags override the config keys.
+
+### Manifest: build a curated list with docx_manifest.py
+
+Create `manifests/render-manifest.yaml` at the content repo root:
+
+```yaml
+documents:
+  - id: segmentation-overview
+    input: docs/overview_segmentation_poc-architecture.md
+  - id: aap-dr-adr
+    input: decisions/adr_automation_aap-dr.md
+    output: exports/published/adr_automation_aap-dr.docx   # optional override
+```
+
+Each entry needs `id` and `input`; `output`, `org`, and `logo` are optional
+per-document overrides. Then run the wrapper from the content repo root:
 
 ```bash
 python3 ../dac-toolkit/scripts/docx_manifest.py list --content-root . --manifest manifests/render-manifest.yaml
@@ -129,6 +214,15 @@ The render wrapper:
 - falls back to `vars/org.yaml` and `assets/logo/logo.png` when present
 - creates a local `.venv-docx-render/` and installs `docx-build` automatically if needed
 - rewrites Kroki-supported fenced diagrams to generated PNG assets before calling `docx-build`
+
+### Shell pipeline: build all documents with build-docs.sh
+
+```bash
+bash scripts/build-docs.sh /path/to/content-repo
+```
+
+The script auto-detects `vars/org.yaml` and `assets/logo/logo.png` in the
+content directory and passes them to `docx-build`.
 
 ### Build a single document
 
@@ -153,6 +247,19 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | `--org PATH` | YAML file with org identity overrides (name, dept, addr1, addr2, url) |
 | `--output PATH` | Output .docx path. Defaults to input filename with .docx extension. |
 
+```text
+docx-build-all [--config PATH] [--org PATH] [--logo PATH] [--dry-run] [--force] [--report-file PATH]
+```
+
+| Flag | Description |
+|---|---|
+| `--config PATH` | Path to `docx-build.yml`. Defaults to searching upward from CWD. |
+| `--org PATH` | Org identity YAML. Takes precedence over the `org:` config key. |
+| `--logo PATH` | Logo image (PNG/JPG). Takes precedence over the `logo:` config key. |
+| `--dry-run` | Report what would render; write nothing. |
+| `--force` | Re-render all documents regardless of version or status match. |
+| `--report-file PATH` | Write the build report to a file in addition to stdout. |
+
 ---
 
 ## Supported Markdown Elements
@@ -170,6 +277,7 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | GFM pipe tables | Styled tables with header row and alternating row colors |
 | `![alt](path)` | Embedded images (path relative to source .md file) |
 | `` ```mermaid ``` `` | Mermaid diagrams rendered to PNG and embedded inline |
+| `` ```plantuml ``` `` etc. | Any Kroki-supported diagram fence (PlantUML, Graphviz, D2, ...) rendered to PNG via Kroki — set `DOCX_BUILDER_KROKI_URL` for a self-hosted instance |
 
 ### Heading Numbering
 

--- a/docs/content-repo-conventions.md
+++ b/docs/content-repo-conventions.md
@@ -22,8 +22,9 @@ content-repo/
 │       └── logo.png
 ├── vars/
 │   └── org.yaml
+├── docx-build.yml            # scan-based selection (docx-build-all)
 ├── manifests/
-│   └── render-manifest.yaml
+│   └── render-manifest.yaml  # curated selection (docx_manifest.py)
 └── .docx-work/
 ```
 
@@ -41,6 +42,9 @@ conventions like these over one-off path wiring.
 
 - Preferred shared path: `assets/logo/logo.png`
 - JPG should also remain supported when PNG is not available
+- All render paths (`build-docs.sh`, `docx-build-all`, `docx_manifest.py`)
+  auto-detect this path, so a repo that follows the convention gets its logo
+  on every cover with no configuration
 
 ### Output naming
 
@@ -54,6 +58,37 @@ conventions like these over one-off path wiring.
   structure
 - Wrapper tooling may provision this area differently by platform, but the
   resulting shape should stay predictable to the user
+
+## Content Selection: Two First-Class Approaches
+
+A content repo declares what gets rendered in one of two ways. Both are
+supported long-term — they answer different governance questions, and a repo
+picks the one that matches how it decides what is publishable.
+
+### Scan (`docx-build.yml` + `docx-build-all`)
+
+The repo's working set is the publication set. `docx-build.yml` names the
+folders in scope (`scan:`), carve-outs (`exclude:`), and status filters;
+everything that qualifies renders. This suits repos that publish the whole
+working set and sync `exports/` to a document library as a folder — the
+incremental render index and the `mirror` layout exist for exactly that
+workflow.
+
+### Manifest (`manifests/render-manifest.yaml` + `docx_manifest.py`)
+
+Publication is curated. The manifest is an explicit, reviewable list of
+documents, and the list itself is the governance artifact: a diff to the
+manifest *is* the record of a publication decision. This suits repos where a
+deliberate subset ships, where documents need per-document org/logo/output
+overrides, or where diagram fences should be pre-rendered to committed PNG
+assets (the wrapper rewrites any Kroki-supported fence type; the builder also
+renders those fences inline on every path).
+
+`build-docs.sh` remains the original zero-config shell path — conventional
+folders, everything with front matter — and stays supported alongside both.
+
+See the toolkit README for a full capability comparison and worked examples
+of each config.
 
 ## Manifest Direction
 

--- a/docx_builder/src/docx_builder/batch_cli.py
+++ b/docx_builder/src/docx_builder/batch_cli.py
@@ -5,7 +5,7 @@ Registered in pyproject.toml as:
     docx-build-all = "docx_builder.batch_cli:main"
 
 Usage:
-    docx-build-all [--config PATH] [--org PATH] [--dry-run] [--force] [--report-file PATH]
+    docx-build-all [--config PATH] [--org PATH] [--logo PATH] [--dry-run] [--force] [--report-file PATH]
 
 Execution flow:
     1. Load and validate config (abort with exit 2 on config error)
@@ -102,6 +102,13 @@ parent directory. See the dac-toolkit README for the config schema.
              "Takes precedence over the 'org' key in docx-build.yml.",
     )
     parser.add_argument(
+        '--logo',
+        default=None,
+        metavar='PATH',
+        help="Path to logo image (PNG or JPG) for cover pages. "
+             "Takes precedence over the 'logo' key in docx-build.yml.",
+    )
+    parser.add_argument(
         '--dry-run',
         action='store_true',
         help="Scan and report what would be rendered; do not write any files.",
@@ -155,6 +162,20 @@ parent directory. See the dac-toolkit README for the config schema.
         except (OSError, yaml.YAMLError) as e:
             print(f"Error: cannot load org file {org_path}: {e}", file=sys.stderr)
             sys.exit(2)
+
+    # ── 3b. Resolve logo (CLI --logo takes precedence over config) ────────────
+    # Config-level resolution (explicit key or auto-detected assets/logo/
+    # logo.png) already happened in load_config; only an explicit CLI override
+    # needs checking here. A missing file is an error, not a warning: silently
+    # falling back to the text cover on every document in a batch is exactly
+    # the gap this flag exists to close.
+    if args.logo:
+        logo_path = os.path.abspath(args.logo)
+        if not os.path.isfile(logo_path):
+            print(f"Error: logo file not found: {logo_path}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        logo_path = config.logo
 
     # ── 4. Scan ───────────────────────────────────────────────────────────────
     docs, scan_warnings = scan(config)
@@ -234,6 +255,7 @@ parent directory. See the dac-toolkit README for the config schema.
             ensure_output_dir(output_path)
             build_document(
                 doc.path,
+                logo_path=logo_path,
                 output_path=output_path,
                 org_overrides=org_overrides,
             )

--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -8,6 +8,7 @@ Config schema (docx-build.yml):
 
     export_root: exports/          # required — root folder for DOCX output
     org: vars/org.yaml             # optional — org identity YAML (same as --org flag)
+    logo: assets/logo/logo.png     # optional — cover logo image (same as --logo flag)
     layout: status                 # optional — 'status' (default) or 'mirror'
 
     scan:                          # required — at least one entry
@@ -26,6 +27,14 @@ Config schema (docx-build.yml):
       skip_informational: false    # default: false — render status: Informational docs
 
 Paths in scan and exclude are resolved relative to the config file's directory.
+
+Logo
+────
+    When the 'logo' key is absent, assets/logo/logo.png relative to the config
+    file's directory is used if it exists — the same convention build-docs.sh
+    and docx_manifest.py already auto-detect, so a repo that follows the
+    recommended shape gets its logo on every cover without any config. When no
+    logo is found the cover falls back to the org name as styled text.
 
 Layout
 ──────
@@ -78,6 +87,7 @@ class BatchConfig:
     scan: list[str]           # resolved absolute paths
     exclude: list[str]        # resolved absolute paths
     org: Optional[str]        # resolved absolute path, or None
+    logo: Optional[str]       # resolved absolute path, or None
     options: BatchOptions
     config_path: str          # absolute path to the config file itself
     config_dir: str           # directory containing the config file
@@ -175,6 +185,25 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
     else:
         org = None
 
+    logo_raw = raw.get('logo')
+    if logo_raw:
+        # An explicit key pointing at a missing file is a config error, same as
+        # 'org': failing fast beats silently rendering a whole batch of covers
+        # with the text fallback.
+        logo_resolved = os.path.normpath(os.path.join(config_dir, str(logo_raw)))
+        if not os.path.isfile(logo_resolved):
+            raise ConfigError(
+                f"logo file specified in config not found: {logo_resolved}"
+            )
+        logo: Optional[str] = logo_resolved
+    else:
+        # Auto-detect the conventional location (see "Logo" in the module
+        # docstring). Absence is not an error — the cover has a text fallback.
+        candidate = os.path.normpath(
+            os.path.join(config_dir, 'assets', 'logo', 'logo.png')
+        )
+        logo = candidate if os.path.isfile(candidate) else None
+
     layout = str(raw.get('layout') or DEFAULT_LAYOUT).strip().lower()
     if layout not in LAYOUTS:
         raise ConfigError(
@@ -193,6 +222,7 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         scan=scan,
         exclude=exclude,
         org=org,
+        logo=logo,
         options=options,
         config_path=path,
         config_dir=config_dir,

--- a/docx_builder/src/docx_builder/cover_page.py
+++ b/docx_builder/src/docx_builder/cover_page.py
@@ -330,8 +330,14 @@ def build_cover_page(doc, meta: dict, logo_path: str | None):
             )
 
     if not logo_rendered:
-        # Fallback: org name as styled text when no usable logo file is provided
-        run = logo_para.add_run(ORG_NAME)
+        # Fallback: org name as styled text when no usable logo file is provided.
+        # Resolve through meta['org'] the same way build_cover_footer does —
+        # builder.py merges --org overrides into meta['org'] before calling us,
+        # so reading the module constant directly would print the compiled-in
+        # placeholder ("Acme Corp") on every logo-less cover regardless of the
+        # caller's org.yaml.
+        org = meta.get('org') or {}
+        run = logo_para.add_run(org.get('name', ORG_NAME))
         run.bold = True
         run.font.name = FONT_TITLE
         run.font.size = Pt(14)


### PR DESCRIPTION
## Summary

- **Logo parity for `docx-build-all`** — the batch entry point previously had no logo handling at all, so every cover page silently fell back to text. It now supports an optional `logo:` key in `docx-build.yml` (resolved relative to the config directory, mirroring `org:`), auto-detection of `assets/logo/logo.png` relative to the config directory when the key is absent (the same convention `build-docs.sh` and `docx_manifest.py` already honor), and a `--logo` CLI flag that overrides the config, matching `--org` precedence. An explicit key or flag pointing at a missing file fails fast with exit 2.
- **Cover page fallback bug** — the no-logo text fallback in `cover_page.py` rendered the module constant `ORG_NAME` (`"Acme Corp"`) instead of the caller-supplied org name. It now resolves `meta['org']['name']` exactly the way `build_cover_footer` already did.
- **Dual selection-approach documentation** — `README.md` and `docs/content-repo-conventions.md` now present both content-selection approaches as first-class: scan (`docx-build-all` + `docx-build.yml`) for publish-the-working-set repos and library folder syncs, manifest (`scripts/docx_manifest.py` + `manifests/render-manifest.yaml`) for curated publication lists where the list itself is the governance artifact. Includes a side-by-side capability table and minimal worked configs. `build-docs.sh` is documented as the original, still-supported zero-config shell path. Nothing is deprecated.

## Backwards compatibility

A `docx-build.yml` with no `logo:` key behaves exactly as before, apart from the new auto-detection when `assets/logo/logo.png` exists next to the config.

## Verification (run against a real content repo)

- `load_config` on a config with no `logo:` key and no logo file present returns `logo=None`; a real-repo `--dry-run` over 84 documents runs clean.
- Explicit `logo:` key resolves to an absolute path; pointing it at a missing file raises `ConfigError`.
- Auto-detection picks up `assets/logo/logo.png` relative to the config directory.
- A real `docx-build-all` render with `logo:` set embeds `word/media/image1.png` in the output DOCX instead of falling back to text.
- With no logo anywhere, the cover fallback now shows the org.yaml name and `document.xml` contains no "Acme Corp".
- `--logo` flag overrides a config without the key; `--logo` with a missing file exits 2.
- Full `docx_builder` test suite passes (16 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
