### PR TITLE
feat(diagrams): render any Kroki-supported diagram fence on every build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Documentation-as-Code toolkit that converts Markdown with YAML front matter into
 styled DOCX documents with cover pages, table of contents, revision history,
-auto-numbered headings, and embedded Mermaid diagrams.
+auto-numbered headings, and embedded diagrams (Mermaid plus any
+Kroki-supported language — PlantUML, Graphviz, D2, and more).
 
 ---
 
@@ -170,6 +171,7 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | GFM pipe tables | Styled tables with header row and alternating row colors |
 | `![alt](path)` | Embedded images (path relative to source .md file) |
 | `` ```mermaid ``` `` | Mermaid diagrams rendered to PNG and embedded inline |
+| `` ```plantuml ``` `` etc. | Any Kroki-supported diagram fence (PlantUML, Graphviz, D2, ...) rendered to PNG via Kroki — set `DOCX_BUILDER_KROKI_URL` for a self-hosted instance |
 
 ### Heading Numbering
 

--- a/docx_builder/src/docx_builder/builder.py
+++ b/docx_builder/src/docx_builder/builder.py
@@ -38,7 +38,7 @@ from .revision_history import build_revision_table
 from .sections import add_section_break, add_body_footer
 from .cover_page import set_toc_page_numbering_start
 from .markdown_parser import HtmlToDocx, extract_md_tables, render_md_table
-from .diagrams import extract_mermaid_fences, render_diagram
+from .diagrams import extract_diagram_fences, render_diagram
 
 
 def build_document(
@@ -137,9 +137,11 @@ def build_document(
     body_md = re.sub(r'^(\s*)-\s+\[ \]\s+', r'\1- ' + '\u2610 ',
                      body_md, flags=re.MULTILINE)
 
-    # Step 1: Extract inline Mermaid fences before mistune sees them.
-    #         Replaces each ```mermaid block with a __MERMAID_N__ placeholder.
-    body_md_no_mermaid, mermaid_data_list = extract_mermaid_fences(body_md)
+    # Step 1: Extract inline diagram fences before mistune sees them.
+    #         Replaces each ```mermaid / ```plantuml / ```graphviz / ... block
+    #         (any Kroki-supported language) with a __MERMAID_N__ placeholder.
+    #         Non-diagram fences (```bash, ```yaml, ...) pass through untouched.
+    body_md_no_mermaid, mermaid_data_list = extract_diagram_fences(body_md)
 
     # Step 2: Extract GFM tables (no doc writes yet).
     #         Replaces each pipe table with a __TABLE_N__ placeholder.

--- a/docx_builder/src/docx_builder/diagrams.py
+++ b/docx_builder/src/docx_builder/diagrams.py
@@ -1,39 +1,56 @@
 """
-diagrams.py — Mermaid diagram extraction and rendering for docx_builder.
+diagrams.py — Diagram extraction and rendering for docx_builder.
 
 Pipeline role
 -------------
-Inline Mermaid fences (```mermaid blocks) are extracted from the markdown
-source before the mistune pass and replaced with __MERMAID_N__ placeholders.
+Inline diagram fences — ```mermaid blocks plus any fence whose info string is
+a Kroki-supported diagram language (```plantuml, ```graphviz, ```d2, ...) —
+are extracted from the markdown source before the mistune pass and replaced
+with __MERMAID_N__ placeholders. (The token name predates multi-language
+support and is kept for compatibility; it covers all diagram languages.)
 builder.py calls render_diagram() for each placeholder while iterating body
 segments in source order, so diagrams land in the correct position relative
 to surrounding paragraphs.
 
+Fences whose info string is NOT a supported diagram language (```bash,
+```yaml, ```python, ...) are left completely untouched and continue to
+render as ordinary code blocks.
+
 Rendering backends
 ------------------
-Backends are tried in this order:
+Mermaid fences try backends in this order:
 
   1. mmdc       — Mermaid CLI (Node.js). Best output quality and the only
                   backend that supports custom CSS themes. Used automatically
                   when mmdc is found in PATH (GitHub Actions, devspace).
                   Set DOCX_BUILDER_MERMAID_BACKEND=mmdc to require it.
 
-  2. kroki.io   — Public HTTP API at https://kroki.io (primary API backend).
-                  More reliable than mermaid.ink; uses zlib+base64url encoding.
-                  No local dependencies; requires internet access at build time.
+  2. Kroki      — HTTP API (https://kroki.io by default, or a self-hosted
+                  instance via DOCX_BUILDER_KROKI_URL). Diagram source is
+                  POSTed to {kroki_url}/{diagram_type}/png. No local
+                  dependencies; requires network access at build time.
 
   3. mermaid.ink — Public HTTP API at https://mermaid.ink (secondary API).
-                   Tried if kroki.io fails. Uses plain base64url encoding.
+                   Tried if Kroki fails. Uses plain base64url encoding.
 
   4. Placeholder — If all backends fail (offline, syntax error, no Node.js),
-                   a styled warning block containing the raw Mermaid source is
+                   a styled warning block containing the raw diagram source is
                    inserted instead of crashing the build.
 
-Environment variable override:
+All other diagram languages render via Kroki only (backend 2), falling back
+to the styled placeholder (backend 4) on any failure.
+
+Environment variable overrides:
     DOCX_BUILDER_MERMAID_BACKEND=auto        (default — mmdc → kroki → ink)
     DOCX_BUILDER_MERMAID_BACKEND=mmdc        (require mmdc only)
-    DOCX_BUILDER_MERMAID_BACKEND=kroki       (skip mmdc, kroki.io only)
+    DOCX_BUILDER_MERMAID_BACKEND=kroki       (skip mmdc, Kroki only)
     DOCX_BUILDER_MERMAID_BACKEND=mermaid_ink (skip mmdc and kroki, ink only)
+
+    DOCX_BUILDER_KROKI_URL=https://kroki.io  (default — public Kroki API)
+    DOCX_BUILDER_KROKI_URL=http://127.0.0.1:8000
+                                             (self-hosted Kroki instance;
+                                             applies to ALL diagram languages,
+                                             including the mermaid Kroki step)
 
 Custom CSS (mmdc only)
 ----------------------
@@ -46,14 +63,15 @@ Supported image formats for ![]() references
 python-docx supports: PNG, JPG/JPEG, GIF, TIFF, BMP, EMF, WMF.
 SVG is NOT supported natively — export to PNG before referencing.
 
-Caption syntax for inline Mermaid fences
+Caption syntax for inline diagram fences
 -----------------------------------------
     ```mermaid caption="Figure 1 — DevOps Lifecycle"
     flowchart LR
         A --> B
     ```
 
-The caption attribute is optional. Alt text in ![]() image references is
+The caption attribute is optional and works on any diagram fence
+(```plantuml caption="..." etc.). Alt text in ![]() image references is
 used as the caption for path-referenced images.
 """
 
@@ -61,7 +79,6 @@ import os
 import re
 import base64
 import shutil
-import zlib
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -95,46 +112,116 @@ DIAGRAM_RENDER_SCALE_DEFAULT: float = 2.0
 DIAGRAM_RENDER_SCALE_MIN: float = 1.0
 DIAGRAM_RENDER_SCALE_MAX: float = 4.0
 
+# Default Kroki endpoint. Override with DOCX_BUILDER_KROKI_URL to point at a
+# self-hosted Kroki instance (e.g. http://127.0.0.1:8000).
+DEFAULT_KROKI_URL: str = 'https://kroki.io'
+
+# Fence info string → Kroki diagram type.
+# Keys are the languages recognised as diagram fences; values are the path
+# segment used in the Kroki render URL ({kroki_url}/{type}/png). Most map
+# 1:1; aliases like ```dot → graphviz are the exception.
+#
+# KEEP IN STEP with SUPPORTED_DIAGRAM_TYPES in scripts/docx_manifest.py —
+# scripts/ is not an importable package, so the list is duplicated there.
+# Any fence whose info string is NOT in this map is an ordinary code block
+# (```bash, ```yaml, ```python, ...) and must never be treated as a diagram.
+KROKI_LANGUAGE_TYPES: dict[str, str] = {
+    'mermaid': 'mermaid',
+    'plantuml': 'plantuml',
+    'c4plantuml': 'c4plantuml',
+    'graphviz': 'graphviz',
+    'dot': 'graphviz',
+    'd2': 'd2',
+    'pikchr': 'pikchr',
+    'erd': 'erd',
+    'svgbob': 'svgbob',
+    'nomnoml': 'nomnoml',
+    'structurizr': 'structurizr',
+    'ditaa': 'ditaa',
+    'seqdiag': 'seqdiag',
+    'blockdiag': 'blockdiag',
+    'nwdiag': 'nwdiag',
+    'packetdiag': 'packetdiag',
+    'rackdiag': 'rackdiag',
+    'umlet': 'umlet',
+    'vega': 'vega',
+    'vegalite': 'vegalite',
+    'wavedrom': 'wavedrom',
+    'wireviz': 'wireviz',
+    'dbml': 'dbml',
+    'bpmn': 'bpmn',
+    'excalidraw': 'excalidraw',
+    'bytefield': 'bytefield',
+    'goat': 'goat',
+    'symbolator': 'symbolator',
+}
+
 
 # ── Extraction ────────────────────────────────────────────────────────────────
 
-def extract_mermaid_fences(md_text: str) -> tuple[str, list[dict]]:
+def extract_diagram_fences(md_text: str) -> tuple[str, list[dict]]:
     """
-    Extract ```mermaid code fences from markdown and replace with placeholders.
+    Extract diagram code fences from markdown and replace with placeholders.
+
+    A fence is a diagram fence when its info string (the word after the
+    opening backticks) is a key in KROKI_LANGUAGE_TYPES — ```mermaid,
+    ```plantuml, ```graphviz, ```d2, etc. Any other fence (```bash,
+    ```yaml, ```python, plain ```) is NOT a diagram: it is returned to the
+    markdown stream byte-for-byte unchanged and renders as an ordinary
+    code block.
 
     Returns (processed_text, diagram_data_list) where:
-      - processed_text has each fence replaced by a __MERMAID_N__ token
+      - processed_text has each diagram fence replaced by a __MERMAID_N__
+        token (name kept for compatibility; covers all diagram languages)
       - diagram_data_list[N] is a dict:
-            {'source': str, 'caption': str | None}
+            {'source': str, 'caption': str | None,
+             'language': str, 'kroki_type': str}
 
     The caller (builder.py) splits the processed text on __MERMAID_N__ and
-    __TABLE_N__ tokens and calls render_diagram() for each Mermaid token,
+    __TABLE_N__ tokens and calls render_diagram() for each diagram token,
     keeping all elements in source order.
 
     Caption is parsed from an optional caption="..." attribute on the opening
     fence line:
         ```mermaid caption="Figure 1 — DevOps Lifecycle"
     """
-    # Matches ```mermaid<optional attrs>\n<body>\n``` — non-greedy body
+    # Matches ```<language><optional attrs>\n<body>\n``` — non-greedy body.
+    # The language must start at the fence with no gap; whether it is a
+    # diagram is decided in _extract so non-diagram fences pass through.
     fence_re = re.compile(
-        r'^```mermaid([^\n]*)\n(.*?)^```',
+        r'^```([A-Za-z][A-Za-z0-9_-]*)([^\n]*)\n(.*?)^```',
         re.MULTILINE | re.DOTALL,
     )
     diagrams: list[dict] = []
 
     def _extract(m: re.Match) -> str:
-        attrs_str = m.group(1).strip()
-        source    = m.group(2).strip()
+        language = m.group(1).strip().lower()
+        if language not in KROKI_LANGUAGE_TYPES:
+            # Ordinary code block (```bash, ```yaml, ...) — leave untouched.
+            return m.group(0)
+
+        attrs_str = m.group(2).strip()
+        source    = m.group(3).strip()
 
         cap_match = re.search(r'caption=["\']([^"\']+)["\']', attrs_str)
         caption   = cap_match.group(1) if cap_match else None
 
         idx = len(diagrams)
-        diagrams.append({'source': source, 'caption': caption})
+        diagrams.append({
+            'source': source,
+            'caption': caption,
+            'language': language,
+            'kroki_type': KROKI_LANGUAGE_TYPES[language],
+        })
         return f'\n__MERMAID_{idx}__\n'
 
     processed = fence_re.sub(_extract, md_text)
     return processed, diagrams
+
+
+# Backwards-compatible alias — the function handled only ```mermaid fences
+# before multi-language Kroki support landed. Existing callers keep working.
+extract_mermaid_fences = extract_diagram_fences
 
 
 # ── Rendering ─────────────────────────────────────────────────────────────────
@@ -147,90 +234,123 @@ def render_diagram(
     css_path: str | None = None,
 ) -> None:
     """
-    Render a single Mermaid diagram into the document at the current position.
+    Render a single diagram into the document at the current position.
 
-    Tries mmdc first (if in PATH or forced via env var), then kroki, then
-    mermaid.ink, and finally falls back to a styled placeholder so the build
-    never hard-fails.
+    Mermaid diagrams try mmdc first (if in PATH or forced via env var), then
+    Kroki, then mermaid.ink. Every other diagram language renders via Kroki
+    only. Both paths fall back to a styled placeholder so the build never
+    hard-fails.
 
     Args:
         doc:           The python-docx Document object.
         diagram_data:  Dict with keys 'source' (str) and 'caption' (str|None).
+                       Optional 'language' and 'kroki_type' keys (added by
+                       extract_diagram_fences) select the render path;
+                       both default to 'mermaid' for older callers.
         tmp_dir:       Temporary directory for intermediate PNG files.
         mermaid_theme: mermaid.ink theme string (ignored by mmdc — use css_path).
         css_path:      Optional path to a .css file passed to mmdc --cssFile.
     """
-    source  = diagram_data['source']
-    caption = diagram_data.get('caption')
+    source     = diagram_data['source']
+    caption    = diagram_data.get('caption')
+    language   = diagram_data.get('language', 'mermaid')
+    kroki_type = diagram_data.get('kroki_type', KROKI_LANGUAGE_TYPES.get(language, language))
     render_scale = _get_mermaid_render_scale()
 
     digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
-    png_path = os.path.join(tmp_dir, f'mermaid_{digest}.png')
+    png_path = os.path.join(tmp_dir, f'{language}_{digest}.png')
     rendered = False
 
-    backend = os.environ.get('DOCX_BUILDER_MERMAID_BACKEND', 'auto').lower()
+    if language == 'mermaid':
+        backend = os.environ.get('DOCX_BUILDER_MERMAID_BACKEND', 'auto').lower()
 
-    # 1. mmdc — best quality, supports custom CSS; used when in PATH
-    if backend in ('auto', 'mmdc') and shutil.which('mmdc'):
-        _css = css_path or os.environ.get('DOCX_BUILDER_MERMAID_CSS')
-        rendered = _render_via_mmdc(
+        # 1. mmdc — best quality, supports custom CSS; used when in PATH
+        if backend in ('auto', 'mmdc') and shutil.which('mmdc'):
+            _css = css_path or os.environ.get('DOCX_BUILDER_MERMAID_CSS')
+            rendered = _render_via_mmdc(
+                source,
+                png_path,
+                css_path=_css,
+                scale=render_scale,
+            )
+
+        # 2. Kroki — primary API backend, generally more reliable
+        if not rendered and backend in ('auto', 'kroki'):
+            rendered = _render_via_kroki(source, png_path, scale=render_scale)
+
+        # 3. mermaid.ink — secondary public API fallback
+        if not rendered and backend in ('auto', 'mermaid_ink'):
+            rendered = _render_via_mermaid_ink(
+                source,
+                png_path,
+                theme=mermaid_theme,
+                scale=render_scale,
+            )
+    else:
+        # Non-mermaid languages have exactly one backend: Kroki.
+        rendered = _render_via_kroki(
             source,
             png_path,
-            css_path=_css,
-            scale=render_scale,
-        )
-
-    # 2. kroki.io — primary public API, generally more reliable
-    if not rendered and backend in ('auto', 'kroki'):
-        rendered = _render_via_kroki(source, png_path, scale=render_scale)
-
-    # 3. mermaid.ink — secondary public API fallback
-    if not rendered and backend in ('auto', 'mermaid_ink'):
-        rendered = _render_via_mermaid_ink(
-            source,
-            png_path,
-            theme=mermaid_theme,
+            diagram_type=kroki_type,
             scale=render_scale,
         )
 
     if rendered and os.path.isfile(png_path):
         _embed_image(doc, png_path, caption)
     else:
-        _embed_placeholder(doc, source, caption)
+        _embed_placeholder(doc, source, caption, language=language)
 
 
 # ── Private: rendering backends ───────────────────────────────────────────────
 
-def _render_via_kroki(source: str, output_path: str, scale: float = DIAGRAM_RENDER_SCALE_DEFAULT) -> bool:
-    """
-    Fetch a rendered PNG from the kroki.io public API.
+def _get_kroki_url() -> str:
+    """Return the Kroki base URL from the environment (default: kroki.io)."""
+    raw = os.environ.get('DOCX_BUILDER_KROKI_URL', '').strip()
+    return (raw or DEFAULT_KROKI_URL).rstrip('/')
 
-    kroki.io uses zlib compression + URL-safe base64 encoding of the diagram
-    source, which is more compact and generally more reliable than mermaid.ink.
-    Supports Mermaid and many other diagram types. No local dependencies.
+
+def _render_via_kroki(
+    source: str,
+    output_path: str,
+    diagram_type: str = 'mermaid',
+    scale: float = DIAGRAM_RENDER_SCALE_DEFAULT,
+) -> bool:
+    """
+    Fetch a rendered PNG from a Kroki server.
+
+    The diagram source is POSTed as text/plain to
+    {kroki_url}/{diagram_type}/png — the same form scripts/docx_manifest.py
+    uses, and it avoids URL-length limits that the GET encoding hits on
+    large diagrams. The endpoint defaults to the public https://kroki.io
+    API and can point at a self-hosted instance via DOCX_BUILDER_KROKI_URL.
+    Supports Mermaid and every other Kroki diagram type. No local
+    dependencies.
 
     Returns True on success, False on any network or API error.
     """
     try:
-        compressed = zlib.compress(source.encode('utf-8'), level=9)
-        encoded    = base64.urlsafe_b64encode(compressed).decode('ascii')
         params = urllib.parse.urlencode({'scale': _format_scale_query_value(scale)})
-        url = f'https://kroki.io/mermaid/png/{encoded}?{params}'
+        url = f'{_get_kroki_url()}/{diagram_type}/png?{params}'
         req = urllib.request.Request(
             url,
-            headers={'User-Agent': 'docx-builder/1.0'},
+            data=source.encode('utf-8'),
+            headers={
+                'User-Agent': 'docx-builder/1.0',
+                'Content-Type': 'text/plain; charset=utf-8',
+            },
+            method='POST',
         )
         with urllib.request.urlopen(req, timeout=20) as resp:
             content_type = resp.headers.get('Content-Type', '')
             if 'image' not in content_type:
-                print(f'  [diagrams] kroki.io returned non-image '
+                print(f'  [diagrams] Kroki returned non-image '
                       f'content-type: {content_type}')
                 return False
             with open(output_path, 'wb') as f:
                 f.write(resp.read())
         return True
     except (urllib.error.URLError, OSError) as exc:
-        print(f'  [diagrams] kroki.io render failed: {exc}')
+        print(f'  [diagrams] Kroki render failed ({diagram_type}): {exc}')
         return False
 
 
@@ -360,29 +480,36 @@ def _embed_image(doc, img_path: str, caption: str | None) -> None:
         _add_caption(doc, caption)
 
 
-def _embed_placeholder(doc, source: str, caption: str | None) -> None:
+def _embed_placeholder(doc, source: str, caption: str | None,
+                       language: str = 'mermaid') -> None:
     """
     Emit a styled warning block when diagram rendering fails.
 
-    Preserves the raw Mermaid source in a code-style paragraph so the
+    Preserves the raw diagram source in a code-style paragraph so the
     document author can see the intent. Does not raise an exception.
+    The hint text names the language and its remedy: mermaid suggests the
+    CLI install; every other language points at the Kroki endpoint.
     """
     from .xml_helpers import para_spacing, set_run_color
+
+    if language == 'mermaid':
+        hint = ('\u26a0 Diagram could not be rendered '
+                '(install @mermaid-js/mermaid-cli or check internet access)')
+    else:
+        hint = (f'\u26a0 {language} diagram could not be rendered '
+                f'(check Kroki endpoint: {_get_kroki_url()})')
 
     # Warning banner
     warn = doc.add_paragraph()
     para_spacing(warn, before=120, after=20)
-    run = warn.add_run(
-        '\u26a0 Diagram could not be rendered '
-        '(install @mermaid-js/mermaid-cli or check internet access)'
-    )
+    run = warn.add_run(hint)
     run.bold      = True
     run.italic    = True
     run.font.name = FONT_BODY
     run.font.size = Pt(9)
     set_run_color(run, DARK_NAVY)
 
-    # Mermaid source in code style with grey background
+    # Diagram source in code style with grey background
     p   = doc.add_paragraph()
     pPr = p._p.get_or_add_pPr()
     shd = OxmlElement('w:shd')

--- a/docx_builder/tests/test_diagrams.py
+++ b/docx_builder/tests/test_diagrams.py
@@ -114,3 +114,156 @@ class TestMermaidRenderScale(unittest.TestCase):
                 )
 
         self.assertTrue(ok)
+
+
+class TestDiagramFenceExtraction(unittest.TestCase):
+    def test_mermaid_fence_extracted_with_caption(self):
+        md = (
+            'Intro text.\n\n'
+            '```mermaid caption="Figure 1"\n'
+            'flowchart LR\n'
+            '    A --> B\n'
+            '```\n\n'
+            'Outro text.\n'
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertIn("__MERMAID_0__", processed)
+        self.assertNotIn("```mermaid", processed)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["caption"], "Figure 1")
+        self.assertEqual(data[0]["language"], "mermaid")
+        self.assertEqual(data[0]["kroki_type"], "mermaid")
+        self.assertIn("A --> B", data[0]["source"])
+
+    def test_kroki_language_fences_extracted(self):
+        md = (
+            "```plantuml\n@startuml\nA -> B\n@enduml\n```\n\n"
+            "```graphviz\ndigraph G { a -> b }\n```\n\n"
+            "```dot\ndigraph G { c -> d }\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(len(data), 3)
+        self.assertEqual(
+            [d["language"] for d in data], ["plantuml", "graphviz", "dot"]
+        )
+        # ```dot is an alias for the graphviz Kroki type
+        self.assertEqual(
+            [d["kroki_type"] for d in data], ["plantuml", "graphviz", "graphviz"]
+        )
+        for idx in range(3):
+            self.assertIn(f"__MERMAID_{idx}__", processed)
+
+    def test_non_diagram_fences_untouched(self):
+        # ```bash / ```yaml / ```python are ordinary code blocks and must be
+        # returned byte-for-byte — the highest-risk regression for this corpus.
+        md = (
+            "```bash\necho hello\n```\n\n"
+            "```yaml\nkey: value\n```\n\n"
+            "```python\nprint('hi')\n```\n\n"
+            "```text\nplain\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(processed, md)
+        self.assertEqual(data, [])
+
+    def test_mixed_fences_only_extract_diagrams(self):
+        md = (
+            "```bash\necho one\n```\n\n"
+            "```mermaid\nflowchart LR\n    A --> B\n```\n\n"
+            "```yaml\nkey: value\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["language"], "mermaid")
+        self.assertIn("```bash\necho one\n```", processed)
+        self.assertIn("```yaml\nkey: value\n```", processed)
+        self.assertNotIn("```mermaid", processed)
+
+    def test_plain_fence_untouched(self):
+        md = "```\nno info string\n```\n"
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(processed, md)
+        self.assertEqual(data, [])
+
+    def test_extract_mermaid_fences_alias(self):
+        # Backwards-compatible alias must keep working for older callers.
+        self.assertIs(diagrams.extract_mermaid_fences, diagrams.extract_diagram_fences)
+
+
+class TestKrokiBackend(unittest.TestCase):
+    def test_kroki_posts_source_to_typed_endpoint(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["data"] = req.data
+            return _FakeResponse(b"png-bytes")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = str(Path(tmp_dir) / "diagram.png")
+            with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+                ok = diagrams._render_via_kroki(
+                    "digraph G { a -> b }",
+                    output_path,
+                    diagram_type="graphviz",
+                )
+
+        self.assertTrue(ok)
+        self.assertTrue(seen["url"].startswith("https://kroki.io/graphviz/png"))
+        self.assertEqual(seen["method"], "POST")
+        self.assertEqual(seen["data"], b"digraph G { a -> b }")
+
+    def test_kroki_url_env_override(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            return _FakeResponse(b"png-bytes")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = str(Path(tmp_dir) / "diagram.png")
+            with mock.patch.dict(
+                "os.environ",
+                {"DOCX_BUILDER_KROKI_URL": "http://127.0.0.1:8000/"},
+                clear=False,
+            ):
+                with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+                    ok = diagrams._render_via_kroki(
+                        "flowchart LR\nA-->B",
+                        output_path,
+                    )
+
+        self.assertTrue(ok)
+        self.assertTrue(seen["url"].startswith("http://127.0.0.1:8000/mermaid/png"))
+
+    def test_render_diagram_falls_back_to_placeholder_on_unreachable_kroki(self):
+        # A bogus Kroki host must never crash the build — the diagram degrades
+        # to the styled placeholder block containing the raw source.
+        import docx
+
+        doc = docx.Document()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch.dict(
+                "os.environ",
+                {"DOCX_BUILDER_KROKI_URL": "http://nonexistent.invalid"},
+                clear=False,
+            ):
+                diagrams.render_diagram(
+                    doc,
+                    {
+                        "source": "digraph G { a -> b }",
+                        "caption": None,
+                        "language": "graphviz",
+                        "kroki_type": "graphviz",
+                    },
+                    tmp_dir,
+                )
+
+        text = "\n".join(p.text for p in doc.paragraphs)
+        self.assertIn("digraph G { a -> b }", text)
+        self.assertIn("could not be rendered", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docx_manifest.py
+++ b/scripts/docx_manifest.py
@@ -20,6 +20,9 @@ import yaml
 TOOLKIT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST_NAME = Path("manifests") / "render-manifest.yaml"
 DEFAULT_KROKI_URL = "http://127.0.0.1:8000"
+# KEEP IN STEP with KROKI_LANGUAGE_TYPES in
+# docx_builder/src/docx_builder/diagrams.py (scripts/ is not an importable
+# package, so the mapping is duplicated there).
 SUPPORTED_DIAGRAM_TYPES = {
     "mermaid": "mermaid",
     "plantuml": "plantuml",
@@ -48,6 +51,7 @@ SUPPORTED_DIAGRAM_TYPES = {
     "excalidraw": "excalidraw",
     "bytefield": "bytefield",
     "goat": "goat",
+    "symbolator": "symbolator",
 }
 FENCE_RE = re.compile(r"```([A-Za-z0-9_-]+)[^\n]*\n(.*?)\n```", re.DOTALL)
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
## What now renders that did not before

The builder itself (used by `docx-build`, `docx-build-all`, and `build-docs.sh`) previously extracted only ```` ```mermaid ```` fences; every other diagram language rendered only through the `scripts/docx_manifest.py` wrapper. Now any fenced block whose info string is a Kroki-supported diagram language is extracted and embedded as a PNG on **every** build path:

`plantuml`, `c4plantuml`, `graphviz`/`dot`, `d2`, `pikchr`, `erd`, `svgbob`, `nomnoml`, `structurizr`, `ditaa`, `seqdiag`, `blockdiag`, `nwdiag`, `packetdiag`, `rackdiag`, `umlet`, `vega`, `vegalite`, `wavedrom`, `wireviz`, `dbml`, `bpmn`, `excalidraw`, `bytefield`, `goat`, `symbolator`.

The map lives in `KROKI_LANGUAGE_TYPES` (diagrams.py) and is kept in step with `SUPPORTED_DIAGRAM_TYPES` in `scripts/docx_manifest.py` via cross-referencing comments (`symbolator` added there to match).

## Routing

- **mermaid** keeps its exact backend chain: `mmdc` → Kroki → mermaid.ink → styled placeholder. Existing documents render identically. `extract_mermaid_fences` remains as a compatible alias of the new `extract_diagram_fences`.
- **Every other language** renders via Kroki only, falling back to the styled placeholder (raw source in a code-style block) on any failure — a diagram error never crashes a build.

## Env var

`DOCX_BUILDER_KROKI_URL` — Kroki endpoint for **all** diagram languages (including mermaid's Kroki step). Defaults to `https://kroki.io`; point it at a self-hosted instance (e.g. `http://127.0.0.1:8000`). Documented in the diagrams.py module docstring alongside `DOCX_BUILDER_MERMAID_BACKEND`. The Kroki backend now POSTs source to `{kroki_url}/{type}/png` (the same form `docx_manifest.py` uses), avoiding URL-length limits of the old zlib+base64url GET encoding.

## Regression guard for non-diagram code fences

The highest-risk regression: ```` ```bash ````, ```` ```yaml ````, ```` ```python ```` are everywhere in the content corpus and must stay code blocks. The extractor scans every fence but returns any fence whose info string is not in the language map **byte-for-byte unchanged** (plain ```` ``` ```` fences never match at all). Covered by explicit unit tests (`test_non_diagram_fences_untouched`, `test_mixed_fences_only_extract_diagrams`, `test_plain_fence_untouched`).

## Verification

- 16/16 unit tests pass (`python -m unittest discover -s tests`), including 9 new tests.
- End-to-end build of a fixture with mermaid + graphviz + plantuml + bash/yaml/python fences against public kroki.io: 3 inline images, 0 placeholders, all code fences preserved as text.
- Same fixture with `DOCX_BUILDER_KROKI_URL=http://kroki.nonexistent.invalid` and `DOCX_BUILDER_MERMAID_BACKEND=kroki`: build completes, 3 styled placeholders, no exception.
- Real corpus document (`docs/overview_automation_development-as-code.md` from the content repo) builds with its mermaid diagram rendered as an image (mmdc not installed locally, so it exercised the Kroki HTTP path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)