### PR TITLE
Honour bare-name excludes at any depth

### DIFF
--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -86,6 +86,7 @@ class BatchConfig:
     export_root: str          # resolved absolute path
     scan: list[str]           # resolved absolute paths
     exclude: list[str]        # resolved absolute paths
+    exclude_names: list[str]  # bare names, matched at any depth
     org: Optional[str]        # resolved absolute path, or None
     logo: Optional[str]       # resolved absolute path, or None
     options: BatchOptions
@@ -172,7 +173,27 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
     exclude_raw = raw.get('exclude') or []
     if isinstance(exclude_raw, str):
         exclude_raw = [exclude_raw]    # single string → one-element list
-    exclude = [os.path.normpath(os.path.join(config_dir, str(e))) for e in exclude_raw]
+
+    # An exclude entry is read one of two ways:
+    #
+    #   'initiatives/old/'  contains a separator -> a PATH, rooted at config_dir
+    #   'archive'           a bare name          -> matched at ANY depth
+    #
+    # The bare-name form exists because the natural thing to write is 'archive/',
+    # meaning "archived material wherever it lives". Resolving that as a path
+    # produced <repo>/archive, which usually does not exist, so nested archive
+    # folders were scanned anyway - and build-docs.sh, which prunes */archive/*
+    # at any depth, disagreed with this tool about what gets published.
+    exclude: list[str] = []
+    exclude_names: list[str] = []
+    for e in exclude_raw:
+        entry = str(e).strip().rstrip('/' + os.sep)
+        if not entry:
+            continue
+        if '/' in entry or os.sep in entry:
+            exclude.append(os.path.normpath(os.path.join(config_dir, entry)))
+        else:
+            exclude_names.append(entry)
 
     org_raw = raw.get('org')
     if org_raw:
@@ -221,6 +242,7 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         export_root=export_root,
         scan=scan,
         exclude=exclude,
+        exclude_names=exclude_names,
         org=org,
         logo=logo,
         options=options,

--- a/docx_builder/src/docx_builder/batch_scanner.py
+++ b/docx_builder/src/docx_builder/batch_scanner.py
@@ -60,13 +60,30 @@ def _rel(path: str, base: str) -> str:
         return path
 
 
-def _is_excluded(abs_path: str, exclude_abs: list[str]) -> bool:
-    """Return True if abs_path is at or under any of the exclude_abs roots."""
+def _is_excluded(
+    abs_path: str,
+    exclude_abs: list[str],
+    exclude_names: list[str] | None = None,
+) -> bool:
+    """
+    Return True if abs_path is excluded.
+
+    Two forms, matching the two ways an exclude entry can be written:
+      - exclude_abs:   path roots. Excluded if abs_path is at or under one.
+      - exclude_names: bare names. Excluded if any path component matches,
+                       at any depth - so 'archive' catches
+                       initiatives/<x>/archive/ as well as a top-level one.
+    """
     norm = os.path.normpath(abs_path)
     for excl in exclude_abs:
         excl_norm = os.path.normpath(excl)
         if norm == excl_norm or norm.startswith(excl_norm + os.sep):
             return True
+    if exclude_names:
+        parts = set(norm.split(os.sep))
+        for name in exclude_names:
+            if name in parts:
+                return True
     return False
 
 
@@ -95,13 +112,14 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
             # Prune excluded directories in-place so os.walk never descends into them
             dirnames[:] = sorted(
                 d for d in dirnames
-                if not _is_excluded(os.path.join(dirpath, d), config.exclude)
+                if not _is_excluded(os.path.join(dirpath, d), config.exclude,
+                                    config.exclude_names)
             )
 
             for fname in sorted(f for f in filenames if f.endswith('.md')):
                 fpath = os.path.normpath(os.path.join(dirpath, fname))
 
-                if _is_excluded(fpath, config.exclude):
+                if _is_excluded(fpath, config.exclude, config.exclude_names):
                     continue
 
                 rel = _rel(fpath, config.config_dir)


### PR DESCRIPTION
`exclude: archive/` silently did nothing — entries were always resolved as paths rooted at the config dir, becoming `<repo>/archive` (which doesn't exist), so `initiatives/<x>/archive/` was scanned anyway.

It also made the two render paths **disagree**: `build-docs.sh` prunes `*/archive/*` at any depth; this tool didn't. Archived docs happened not to publish only because they lacked required front matter — adding a `version:` to one would have published it.

Entries are now read two ways: containing a separator → path rooted at config dir (unchanged); a bare name → matched at any depth.

Verified: excludes parse as bare names, nested archive pruned before scanning (its warning is gone), render set unchanged at 87, full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)