### PR TITLE
Release: Kroki multi-language, batch logo, exclude fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Documentation-as-Code toolkit that converts Markdown with YAML front matter into
 styled DOCX documents with cover pages, table of contents, revision history,
-auto-numbered headings, and embedded Mermaid diagrams.
+auto-numbered headings, and embedded diagrams (Mermaid plus any
+Kroki-supported language — PlantUML, Graphviz, D2, and more).
 
 ---
 
@@ -170,6 +171,7 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | GFM pipe tables | Styled tables with header row and alternating row colors |
 | `![alt](path)` | Embedded images (path relative to source .md file) |
 | `` ```mermaid ``` `` | Mermaid diagrams rendered to PNG and embedded inline |
+| `` ```plantuml ``` `` etc. | Any Kroki-supported diagram fence (PlantUML, Graphviz, D2, ...) rendered to PNG via Kroki — set `DOCX_BUILDER_KROKI_URL` for a self-hosted instance |
 
 ### Heading Numbering
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Documentation-as-Code toolkit that converts Markdown with YAML front matter into
 styled DOCX documents with cover pages, table of contents, revision history,
-auto-numbered headings, and embedded Mermaid diagrams.
+auto-numbered headings, and embedded diagrams (Mermaid plus any
+Kroki-supported language — PlantUML, Graphviz, D2, and more).
 
 ---
 
@@ -103,19 +104,103 @@ content-repo/
 └── exports/        Generated DOCX output
 ```
 
-### Build all documents in a content repo
+## Choosing What Gets Rendered
 
-```bash
-bash scripts/build-docs.sh /path/to/content-repo
+The toolkit supports two first-class ways to select which documents get
+rendered, plus the original shell pipeline. All three are supported — none is
+deprecated. Pick the one that matches how your repo decides what is
+publishable.
+
+| Approach | In one sentence |
+|---|---|
+| **Scan** — `docx-build-all` + `docx-build.yml` | Renders everything under the configured `scan:` folders, minus `exclude:` paths and status filters. |
+| **Manifest** — `scripts/docx_manifest.py` + `manifests/render-manifest.yaml` | Renders exactly the documents listed in the manifest, nothing else. |
+| **Shell pipeline** — `scripts/build-docs.sh` | The original path: pre-renders diagrams, then builds every front-mattered Markdown file under the conventional content folders. No config file required. |
+
+### When to choose which
+
+**Choose scan** when the repo's working set *is* the publication set: everything
+under `docs/`, `governance/`, etc. should ship, and the interesting decisions
+are which folders are in scope and which statuses to hold back. Its incremental
+render index and `mirror` layout make it the right fit for repeatedly syncing
+`exports/` to a document library as a folder.
+
+**Choose manifest** when publication is curated: a deliberate subset of the
+repo ships, and the explicit list is itself the governance artifact — a
+reviewable, diffable record of what the org has agreed to publish. Also the
+right fit when documents need per-document org/logo/output overrides, or when
+pre-rendered diagram PNGs should be committed as reviewable assets (the
+manifest wrapper rewrites fences to PNG files before the build; the builder
+itself also renders any Kroki-supported fence inline on every path).
+
+**Choose the shell pipeline** when you want zero configuration: point
+`build-docs.sh` at a content repo shaped like the layout above and it builds
+everything with front matter. It remains fully supported.
+
+### Capability comparison
+
+| Capability | `build-docs.sh` (shell) | `docx-build-all` (scan) | `docx_manifest.py` (manifest) |
+|---|---|---|---|
+| Selection model | Conventional folders (override via `DAC_DOC_DIRS`) | `scan:` + `exclude:` in `docx-build.yml` | Explicit `documents:` list in `render-manifest.yaml` |
+| Config required | None | `docx-build.yml` | `manifests/render-manifest.yaml` |
+| Output layout | Mirrors source tree under `exports/` | `status` (grouped by review state) or `mirror` | Mirrors source tree under `exports/` (per-document `output:` override) |
+| Incremental rebuild | No — always rebuilds | Yes — render index skips unchanged version/status | No — always rebuilds |
+| Status filtering | No | `skip_retired`, `skip_informational` | No — the list is the filter |
+| Diagram handling | Pre-renders Mermaid sources, then the builder handles inline fences | Builder handles inline fences for any Kroki-supported language | Rewrites any Kroki-supported fence (Mermaid, PlantUML, Graphviz, D2, ...) to PNG via a Kroki service, then calls `docx-build` |
+| Logo | Auto-detects `assets/logo/logo.png` | `logo:` key, `--logo` flag, or auto-detects `assets/logo/logo.png` | Per-document `logo:` key, or auto-detects `assets/logo/logo.png` |
+| Org identity | Auto-detects `vars/org.yaml` | `org:` key, `--org` flag, or front matter | Per-document `org:` key, or auto-detects `vars/org.yaml` |
+| Environment | Needs `docx-build` on PATH | Needs `docx-build-all` on PATH | Bootstraps its own `.venv-docx-render/` |
+
+### Scan: build all documents with docx-build-all
+
+Create `docx-build.yml` at the content repo root:
+
+```yaml
+export_root: exports/          # required — root folder for DOCX output
+org: vars/org.yaml             # optional — org identity YAML (same as --org flag)
+logo: assets/logo/logo.png     # optional — cover logo; auto-detected at this path if omitted
+layout: mirror                 # optional — 'status' (default) or 'mirror'
+
+scan:                          # required — folders to render
+  - docs/
+  - governance/
+  - references/
+
+exclude:                       # optional — paths to skip even if under scan
+  - templates/
+  - archive/
+
+options:                       # optional
+  skip_retired: true           # default: true
+  skip_informational: false    # default: false
 ```
 
-The script auto-detects `vars/org.yaml` and `assets/logo/logo.png` in the
-content directory and passes them to `docx-build`.
+Then run it from anywhere inside the repo (it searches upward for the config):
 
-### Build manifest-managed documents from the content repo root
+```bash
+docx-build-all                 # render changed documents
+docx-build-all --dry-run       # report what would render, write nothing
+docx-build-all --force         # re-render everything
+```
 
-When a content repo includes `manifests/render-manifest.yaml`, run the toolkit
-wrapper from the content repo root:
+Paths in the config are resolved relative to the config file's directory.
+`--org` and `--logo` flags override the config keys.
+
+### Manifest: build a curated list with docx_manifest.py
+
+Create `manifests/render-manifest.yaml` at the content repo root:
+
+```yaml
+documents:
+  - id: segmentation-overview
+    input: docs/overview_segmentation_poc-architecture.md
+  - id: aap-dr-adr
+    input: decisions/adr_automation_aap-dr.md
+    output: exports/published/adr_automation_aap-dr.docx   # optional override
+```
+
+Each entry needs `id` and `input`; `output`, `org`, and `logo` are optional
+per-document overrides. Then run the wrapper from the content repo root:
 
 ```bash
 python3 ../dac-toolkit/scripts/docx_manifest.py list --content-root . --manifest manifests/render-manifest.yaml
@@ -129,6 +214,15 @@ The render wrapper:
 - falls back to `vars/org.yaml` and `assets/logo/logo.png` when present
 - creates a local `.venv-docx-render/` and installs `docx-build` automatically if needed
 - rewrites Kroki-supported fenced diagrams to generated PNG assets before calling `docx-build`
+
+### Shell pipeline: build all documents with build-docs.sh
+
+```bash
+bash scripts/build-docs.sh /path/to/content-repo
+```
+
+The script auto-detects `vars/org.yaml` and `assets/logo/logo.png` in the
+content directory and passes them to `docx-build`.
 
 ### Build a single document
 
@@ -153,6 +247,19 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | `--org PATH` | YAML file with org identity overrides (name, dept, addr1, addr2, url) |
 | `--output PATH` | Output .docx path. Defaults to input filename with .docx extension. |
 
+```text
+docx-build-all [--config PATH] [--org PATH] [--logo PATH] [--dry-run] [--force] [--report-file PATH]
+```
+
+| Flag | Description |
+|---|---|
+| `--config PATH` | Path to `docx-build.yml`. Defaults to searching upward from CWD. |
+| `--org PATH` | Org identity YAML. Takes precedence over the `org:` config key. |
+| `--logo PATH` | Logo image (PNG/JPG). Takes precedence over the `logo:` config key. |
+| `--dry-run` | Report what would render; write nothing. |
+| `--force` | Re-render all documents regardless of version or status match. |
+| `--report-file PATH` | Write the build report to a file in addition to stdout. |
+
 ---
 
 ## Supported Markdown Elements
@@ -170,6 +277,7 @@ docx-build INPUT [--logo PATH] [--org PATH] [--output PATH]
 | GFM pipe tables | Styled tables with header row and alternating row colors |
 | `![alt](path)` | Embedded images (path relative to source .md file) |
 | `` ```mermaid ``` `` | Mermaid diagrams rendered to PNG and embedded inline |
+| `` ```plantuml ``` `` etc. | Any Kroki-supported diagram fence (PlantUML, Graphviz, D2, ...) rendered to PNG via Kroki — set `DOCX_BUILDER_KROKI_URL` for a self-hosted instance |
 
 ### Heading Numbering
 

--- a/docs/content-repo-conventions.md
+++ b/docs/content-repo-conventions.md
@@ -22,8 +22,9 @@ content-repo/
 │       └── logo.png
 ├── vars/
 │   └── org.yaml
+├── docx-build.yml            # scan-based selection (docx-build-all)
 ├── manifests/
-│   └── render-manifest.yaml
+│   └── render-manifest.yaml  # curated selection (docx_manifest.py)
 └── .docx-work/
 ```
 
@@ -41,6 +42,9 @@ conventions like these over one-off path wiring.
 
 - Preferred shared path: `assets/logo/logo.png`
 - JPG should also remain supported when PNG is not available
+- All render paths (`build-docs.sh`, `docx-build-all`, `docx_manifest.py`)
+  auto-detect this path, so a repo that follows the convention gets its logo
+  on every cover with no configuration
 
 ### Output naming
 
@@ -54,6 +58,37 @@ conventions like these over one-off path wiring.
   structure
 - Wrapper tooling may provision this area differently by platform, but the
   resulting shape should stay predictable to the user
+
+## Content Selection: Two First-Class Approaches
+
+A content repo declares what gets rendered in one of two ways. Both are
+supported long-term — they answer different governance questions, and a repo
+picks the one that matches how it decides what is publishable.
+
+### Scan (`docx-build.yml` + `docx-build-all`)
+
+The repo's working set is the publication set. `docx-build.yml` names the
+folders in scope (`scan:`), carve-outs (`exclude:`), and status filters;
+everything that qualifies renders. This suits repos that publish the whole
+working set and sync `exports/` to a document library as a folder — the
+incremental render index and the `mirror` layout exist for exactly that
+workflow.
+
+### Manifest (`manifests/render-manifest.yaml` + `docx_manifest.py`)
+
+Publication is curated. The manifest is an explicit, reviewable list of
+documents, and the list itself is the governance artifact: a diff to the
+manifest *is* the record of a publication decision. This suits repos where a
+deliberate subset ships, where documents need per-document org/logo/output
+overrides, or where diagram fences should be pre-rendered to committed PNG
+assets (the wrapper rewrites any Kroki-supported fence type; the builder also
+renders those fences inline on every path).
+
+`build-docs.sh` remains the original zero-config shell path — conventional
+folders, everything with front matter — and stays supported alongside both.
+
+See the toolkit README for a full capability comparison and worked examples
+of each config.
 
 ## Manifest Direction
 

--- a/docx_builder/src/docx_builder/batch_cli.py
+++ b/docx_builder/src/docx_builder/batch_cli.py
@@ -5,7 +5,7 @@ Registered in pyproject.toml as:
     docx-build-all = "docx_builder.batch_cli:main"
 
 Usage:
-    docx-build-all [--config PATH] [--org PATH] [--dry-run] [--force] [--report-file PATH]
+    docx-build-all [--config PATH] [--org PATH] [--logo PATH] [--dry-run] [--force] [--report-file PATH]
 
 Execution flow:
     1. Load and validate config (abort with exit 2 on config error)
@@ -102,6 +102,13 @@ parent directory. See the dac-toolkit README for the config schema.
              "Takes precedence over the 'org' key in docx-build.yml.",
     )
     parser.add_argument(
+        '--logo',
+        default=None,
+        metavar='PATH',
+        help="Path to logo image (PNG or JPG) for cover pages. "
+             "Takes precedence over the 'logo' key in docx-build.yml.",
+    )
+    parser.add_argument(
         '--dry-run',
         action='store_true',
         help="Scan and report what would be rendered; do not write any files.",
@@ -155,6 +162,20 @@ parent directory. See the dac-toolkit README for the config schema.
         except (OSError, yaml.YAMLError) as e:
             print(f"Error: cannot load org file {org_path}: {e}", file=sys.stderr)
             sys.exit(2)
+
+    # ── 3b. Resolve logo (CLI --logo takes precedence over config) ────────────
+    # Config-level resolution (explicit key or auto-detected assets/logo/
+    # logo.png) already happened in load_config; only an explicit CLI override
+    # needs checking here. A missing file is an error, not a warning: silently
+    # falling back to the text cover on every document in a batch is exactly
+    # the gap this flag exists to close.
+    if args.logo:
+        logo_path = os.path.abspath(args.logo)
+        if not os.path.isfile(logo_path):
+            print(f"Error: logo file not found: {logo_path}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        logo_path = config.logo
 
     # ── 4. Scan ───────────────────────────────────────────────────────────────
     docs, scan_warnings = scan(config)
@@ -234,6 +255,7 @@ parent directory. See the dac-toolkit README for the config schema.
             ensure_output_dir(output_path)
             build_document(
                 doc.path,
+                logo_path=logo_path,
                 output_path=output_path,
                 org_overrides=org_overrides,
             )

--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -86,6 +86,7 @@ class BatchConfig:
     export_root: str          # resolved absolute path
     scan: list[str]           # resolved absolute paths
     exclude: list[str]        # resolved absolute paths
+    exclude_names: list[str]  # bare names, matched at any depth
     org: Optional[str]        # resolved absolute path, or None
     logo: Optional[str]       # resolved absolute path, or None
     options: BatchOptions
@@ -172,7 +173,27 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
     exclude_raw = raw.get('exclude') or []
     if isinstance(exclude_raw, str):
         exclude_raw = [exclude_raw]    # single string → one-element list
-    exclude = [os.path.normpath(os.path.join(config_dir, str(e))) for e in exclude_raw]
+
+    # An exclude entry is read one of two ways:
+    #
+    #   'initiatives/old/'  contains a separator -> a PATH, rooted at config_dir
+    #   'archive'           a bare name          -> matched at ANY depth
+    #
+    # The bare-name form exists because the natural thing to write is 'archive/',
+    # meaning "archived material wherever it lives". Resolving that as a path
+    # produced <repo>/archive, which usually does not exist, so nested archive
+    # folders were scanned anyway - and build-docs.sh, which prunes */archive/*
+    # at any depth, disagreed with this tool about what gets published.
+    exclude: list[str] = []
+    exclude_names: list[str] = []
+    for e in exclude_raw:
+        entry = str(e).strip().rstrip('/' + os.sep)
+        if not entry:
+            continue
+        if '/' in entry or os.sep in entry:
+            exclude.append(os.path.normpath(os.path.join(config_dir, entry)))
+        else:
+            exclude_names.append(entry)
 
     org_raw = raw.get('org')
     if org_raw:
@@ -221,6 +242,7 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         export_root=export_root,
         scan=scan,
         exclude=exclude,
+        exclude_names=exclude_names,
         org=org,
         logo=logo,
         options=options,

--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -8,6 +8,7 @@ Config schema (docx-build.yml):
 
     export_root: exports/          # required — root folder for DOCX output
     org: vars/org.yaml             # optional — org identity YAML (same as --org flag)
+    logo: assets/logo/logo.png     # optional — cover logo image (same as --logo flag)
     layout: status                 # optional — 'status' (default) or 'mirror'
 
     scan:                          # required — at least one entry
@@ -26,6 +27,14 @@ Config schema (docx-build.yml):
       skip_informational: false    # default: false — render status: Informational docs
 
 Paths in scan and exclude are resolved relative to the config file's directory.
+
+Logo
+────
+    When the 'logo' key is absent, assets/logo/logo.png relative to the config
+    file's directory is used if it exists — the same convention build-docs.sh
+    and docx_manifest.py already auto-detect, so a repo that follows the
+    recommended shape gets its logo on every cover without any config. When no
+    logo is found the cover falls back to the org name as styled text.
 
 Layout
 ──────
@@ -78,6 +87,7 @@ class BatchConfig:
     scan: list[str]           # resolved absolute paths
     exclude: list[str]        # resolved absolute paths
     org: Optional[str]        # resolved absolute path, or None
+    logo: Optional[str]       # resolved absolute path, or None
     options: BatchOptions
     config_path: str          # absolute path to the config file itself
     config_dir: str           # directory containing the config file
@@ -175,6 +185,25 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
     else:
         org = None
 
+    logo_raw = raw.get('logo')
+    if logo_raw:
+        # An explicit key pointing at a missing file is a config error, same as
+        # 'org': failing fast beats silently rendering a whole batch of covers
+        # with the text fallback.
+        logo_resolved = os.path.normpath(os.path.join(config_dir, str(logo_raw)))
+        if not os.path.isfile(logo_resolved):
+            raise ConfigError(
+                f"logo file specified in config not found: {logo_resolved}"
+            )
+        logo: Optional[str] = logo_resolved
+    else:
+        # Auto-detect the conventional location (see "Logo" in the module
+        # docstring). Absence is not an error — the cover has a text fallback.
+        candidate = os.path.normpath(
+            os.path.join(config_dir, 'assets', 'logo', 'logo.png')
+        )
+        logo = candidate if os.path.isfile(candidate) else None
+
     layout = str(raw.get('layout') or DEFAULT_LAYOUT).strip().lower()
     if layout not in LAYOUTS:
         raise ConfigError(
@@ -193,6 +222,7 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         scan=scan,
         exclude=exclude,
         org=org,
+        logo=logo,
         options=options,
         config_path=path,
         config_dir=config_dir,

--- a/docx_builder/src/docx_builder/batch_scanner.py
+++ b/docx_builder/src/docx_builder/batch_scanner.py
@@ -60,13 +60,30 @@ def _rel(path: str, base: str) -> str:
         return path
 
 
-def _is_excluded(abs_path: str, exclude_abs: list[str]) -> bool:
-    """Return True if abs_path is at or under any of the exclude_abs roots."""
+def _is_excluded(
+    abs_path: str,
+    exclude_abs: list[str],
+    exclude_names: list[str] | None = None,
+) -> bool:
+    """
+    Return True if abs_path is excluded.
+
+    Two forms, matching the two ways an exclude entry can be written:
+      - exclude_abs:   path roots. Excluded if abs_path is at or under one.
+      - exclude_names: bare names. Excluded if any path component matches,
+                       at any depth - so 'archive' catches
+                       initiatives/<x>/archive/ as well as a top-level one.
+    """
     norm = os.path.normpath(abs_path)
     for excl in exclude_abs:
         excl_norm = os.path.normpath(excl)
         if norm == excl_norm or norm.startswith(excl_norm + os.sep):
             return True
+    if exclude_names:
+        parts = set(norm.split(os.sep))
+        for name in exclude_names:
+            if name in parts:
+                return True
     return False
 
 
@@ -95,13 +112,14 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
             # Prune excluded directories in-place so os.walk never descends into them
             dirnames[:] = sorted(
                 d for d in dirnames
-                if not _is_excluded(os.path.join(dirpath, d), config.exclude)
+                if not _is_excluded(os.path.join(dirpath, d), config.exclude,
+                                    config.exclude_names)
             )
 
             for fname in sorted(f for f in filenames if f.endswith('.md')):
                 fpath = os.path.normpath(os.path.join(dirpath, fname))
 
-                if _is_excluded(fpath, config.exclude):
+                if _is_excluded(fpath, config.exclude, config.exclude_names):
                     continue
 
                 rel = _rel(fpath, config.config_dir)

--- a/docx_builder/src/docx_builder/builder.py
+++ b/docx_builder/src/docx_builder/builder.py
@@ -38,7 +38,7 @@ from .revision_history import build_revision_table
 from .sections import add_section_break, add_body_footer
 from .cover_page import set_toc_page_numbering_start
 from .markdown_parser import HtmlToDocx, extract_md_tables, render_md_table
-from .diagrams import extract_mermaid_fences, render_diagram
+from .diagrams import extract_diagram_fences, render_diagram
 
 
 def build_document(
@@ -137,9 +137,11 @@ def build_document(
     body_md = re.sub(r'^(\s*)-\s+\[ \]\s+', r'\1- ' + '\u2610 ',
                      body_md, flags=re.MULTILINE)
 
-    # Step 1: Extract inline Mermaid fences before mistune sees them.
-    #         Replaces each ```mermaid block with a __MERMAID_N__ placeholder.
-    body_md_no_mermaid, mermaid_data_list = extract_mermaid_fences(body_md)
+    # Step 1: Extract inline diagram fences before mistune sees them.
+    #         Replaces each ```mermaid / ```plantuml / ```graphviz / ... block
+    #         (any Kroki-supported language) with a __MERMAID_N__ placeholder.
+    #         Non-diagram fences (```bash, ```yaml, ...) pass through untouched.
+    body_md_no_mermaid, mermaid_data_list = extract_diagram_fences(body_md)
 
     # Step 2: Extract GFM tables (no doc writes yet).
     #         Replaces each pipe table with a __TABLE_N__ placeholder.

--- a/docx_builder/src/docx_builder/cover_page.py
+++ b/docx_builder/src/docx_builder/cover_page.py
@@ -330,8 +330,14 @@ def build_cover_page(doc, meta: dict, logo_path: str | None):
             )
 
     if not logo_rendered:
-        # Fallback: org name as styled text when no usable logo file is provided
-        run = logo_para.add_run(ORG_NAME)
+        # Fallback: org name as styled text when no usable logo file is provided.
+        # Resolve through meta['org'] the same way build_cover_footer does —
+        # builder.py merges --org overrides into meta['org'] before calling us,
+        # so reading the module constant directly would print the compiled-in
+        # placeholder ("Acme Corp") on every logo-less cover regardless of the
+        # caller's org.yaml.
+        org = meta.get('org') or {}
+        run = logo_para.add_run(org.get('name', ORG_NAME))
         run.bold = True
         run.font.name = FONT_TITLE
         run.font.size = Pt(14)

--- a/docx_builder/src/docx_builder/diagrams.py
+++ b/docx_builder/src/docx_builder/diagrams.py
@@ -1,39 +1,56 @@
 """
-diagrams.py — Mermaid diagram extraction and rendering for docx_builder.
+diagrams.py — Diagram extraction and rendering for docx_builder.
 
 Pipeline role
 -------------
-Inline Mermaid fences (```mermaid blocks) are extracted from the markdown
-source before the mistune pass and replaced with __MERMAID_N__ placeholders.
+Inline diagram fences — ```mermaid blocks plus any fence whose info string is
+a Kroki-supported diagram language (```plantuml, ```graphviz, ```d2, ...) —
+are extracted from the markdown source before the mistune pass and replaced
+with __MERMAID_N__ placeholders. (The token name predates multi-language
+support and is kept for compatibility; it covers all diagram languages.)
 builder.py calls render_diagram() for each placeholder while iterating body
 segments in source order, so diagrams land in the correct position relative
 to surrounding paragraphs.
 
+Fences whose info string is NOT a supported diagram language (```bash,
+```yaml, ```python, ...) are left completely untouched and continue to
+render as ordinary code blocks.
+
 Rendering backends
 ------------------
-Backends are tried in this order:
+Mermaid fences try backends in this order:
 
   1. mmdc       — Mermaid CLI (Node.js). Best output quality and the only
                   backend that supports custom CSS themes. Used automatically
                   when mmdc is found in PATH (GitHub Actions, devspace).
                   Set DOCX_BUILDER_MERMAID_BACKEND=mmdc to require it.
 
-  2. kroki.io   — Public HTTP API at https://kroki.io (primary API backend).
-                  More reliable than mermaid.ink; uses zlib+base64url encoding.
-                  No local dependencies; requires internet access at build time.
+  2. Kroki      — HTTP API (https://kroki.io by default, or a self-hosted
+                  instance via DOCX_BUILDER_KROKI_URL). Diagram source is
+                  POSTed to {kroki_url}/{diagram_type}/png. No local
+                  dependencies; requires network access at build time.
 
   3. mermaid.ink — Public HTTP API at https://mermaid.ink (secondary API).
-                   Tried if kroki.io fails. Uses plain base64url encoding.
+                   Tried if Kroki fails. Uses plain base64url encoding.
 
   4. Placeholder — If all backends fail (offline, syntax error, no Node.js),
-                   a styled warning block containing the raw Mermaid source is
+                   a styled warning block containing the raw diagram source is
                    inserted instead of crashing the build.
 
-Environment variable override:
+All other diagram languages render via Kroki only (backend 2), falling back
+to the styled placeholder (backend 4) on any failure.
+
+Environment variable overrides:
     DOCX_BUILDER_MERMAID_BACKEND=auto        (default — mmdc → kroki → ink)
     DOCX_BUILDER_MERMAID_BACKEND=mmdc        (require mmdc only)
-    DOCX_BUILDER_MERMAID_BACKEND=kroki       (skip mmdc, kroki.io only)
+    DOCX_BUILDER_MERMAID_BACKEND=kroki       (skip mmdc, Kroki only)
     DOCX_BUILDER_MERMAID_BACKEND=mermaid_ink (skip mmdc and kroki, ink only)
+
+    DOCX_BUILDER_KROKI_URL=https://kroki.io  (default — public Kroki API)
+    DOCX_BUILDER_KROKI_URL=http://127.0.0.1:8000
+                                             (self-hosted Kroki instance;
+                                             applies to ALL diagram languages,
+                                             including the mermaid Kroki step)
 
 Custom CSS (mmdc only)
 ----------------------
@@ -46,14 +63,15 @@ Supported image formats for ![]() references
 python-docx supports: PNG, JPG/JPEG, GIF, TIFF, BMP, EMF, WMF.
 SVG is NOT supported natively — export to PNG before referencing.
 
-Caption syntax for inline Mermaid fences
+Caption syntax for inline diagram fences
 -----------------------------------------
     ```mermaid caption="Figure 1 — DevOps Lifecycle"
     flowchart LR
         A --> B
     ```
 
-The caption attribute is optional. Alt text in ![]() image references is
+The caption attribute is optional and works on any diagram fence
+(```plantuml caption="..." etc.). Alt text in ![]() image references is
 used as the caption for path-referenced images.
 """
 
@@ -61,7 +79,6 @@ import os
 import re
 import base64
 import shutil
-import zlib
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -95,46 +112,116 @@ DIAGRAM_RENDER_SCALE_DEFAULT: float = 2.0
 DIAGRAM_RENDER_SCALE_MIN: float = 1.0
 DIAGRAM_RENDER_SCALE_MAX: float = 4.0
 
+# Default Kroki endpoint. Override with DOCX_BUILDER_KROKI_URL to point at a
+# self-hosted Kroki instance (e.g. http://127.0.0.1:8000).
+DEFAULT_KROKI_URL: str = 'https://kroki.io'
+
+# Fence info string → Kroki diagram type.
+# Keys are the languages recognised as diagram fences; values are the path
+# segment used in the Kroki render URL ({kroki_url}/{type}/png). Most map
+# 1:1; aliases like ```dot → graphviz are the exception.
+#
+# KEEP IN STEP with SUPPORTED_DIAGRAM_TYPES in scripts/docx_manifest.py —
+# scripts/ is not an importable package, so the list is duplicated there.
+# Any fence whose info string is NOT in this map is an ordinary code block
+# (```bash, ```yaml, ```python, ...) and must never be treated as a diagram.
+KROKI_LANGUAGE_TYPES: dict[str, str] = {
+    'mermaid': 'mermaid',
+    'plantuml': 'plantuml',
+    'c4plantuml': 'c4plantuml',
+    'graphviz': 'graphviz',
+    'dot': 'graphviz',
+    'd2': 'd2',
+    'pikchr': 'pikchr',
+    'erd': 'erd',
+    'svgbob': 'svgbob',
+    'nomnoml': 'nomnoml',
+    'structurizr': 'structurizr',
+    'ditaa': 'ditaa',
+    'seqdiag': 'seqdiag',
+    'blockdiag': 'blockdiag',
+    'nwdiag': 'nwdiag',
+    'packetdiag': 'packetdiag',
+    'rackdiag': 'rackdiag',
+    'umlet': 'umlet',
+    'vega': 'vega',
+    'vegalite': 'vegalite',
+    'wavedrom': 'wavedrom',
+    'wireviz': 'wireviz',
+    'dbml': 'dbml',
+    'bpmn': 'bpmn',
+    'excalidraw': 'excalidraw',
+    'bytefield': 'bytefield',
+    'goat': 'goat',
+    'symbolator': 'symbolator',
+}
+
 
 # ── Extraction ────────────────────────────────────────────────────────────────
 
-def extract_mermaid_fences(md_text: str) -> tuple[str, list[dict]]:
+def extract_diagram_fences(md_text: str) -> tuple[str, list[dict]]:
     """
-    Extract ```mermaid code fences from markdown and replace with placeholders.
+    Extract diagram code fences from markdown and replace with placeholders.
+
+    A fence is a diagram fence when its info string (the word after the
+    opening backticks) is a key in KROKI_LANGUAGE_TYPES — ```mermaid,
+    ```plantuml, ```graphviz, ```d2, etc. Any other fence (```bash,
+    ```yaml, ```python, plain ```) is NOT a diagram: it is returned to the
+    markdown stream byte-for-byte unchanged and renders as an ordinary
+    code block.
 
     Returns (processed_text, diagram_data_list) where:
-      - processed_text has each fence replaced by a __MERMAID_N__ token
+      - processed_text has each diagram fence replaced by a __MERMAID_N__
+        token (name kept for compatibility; covers all diagram languages)
       - diagram_data_list[N] is a dict:
-            {'source': str, 'caption': str | None}
+            {'source': str, 'caption': str | None,
+             'language': str, 'kroki_type': str}
 
     The caller (builder.py) splits the processed text on __MERMAID_N__ and
-    __TABLE_N__ tokens and calls render_diagram() for each Mermaid token,
+    __TABLE_N__ tokens and calls render_diagram() for each diagram token,
     keeping all elements in source order.
 
     Caption is parsed from an optional caption="..." attribute on the opening
     fence line:
         ```mermaid caption="Figure 1 — DevOps Lifecycle"
     """
-    # Matches ```mermaid<optional attrs>\n<body>\n``` — non-greedy body
+    # Matches ```<language><optional attrs>\n<body>\n``` — non-greedy body.
+    # The language must start at the fence with no gap; whether it is a
+    # diagram is decided in _extract so non-diagram fences pass through.
     fence_re = re.compile(
-        r'^```mermaid([^\n]*)\n(.*?)^```',
+        r'^```([A-Za-z][A-Za-z0-9_-]*)([^\n]*)\n(.*?)^```',
         re.MULTILINE | re.DOTALL,
     )
     diagrams: list[dict] = []
 
     def _extract(m: re.Match) -> str:
-        attrs_str = m.group(1).strip()
-        source    = m.group(2).strip()
+        language = m.group(1).strip().lower()
+        if language not in KROKI_LANGUAGE_TYPES:
+            # Ordinary code block (```bash, ```yaml, ...) — leave untouched.
+            return m.group(0)
+
+        attrs_str = m.group(2).strip()
+        source    = m.group(3).strip()
 
         cap_match = re.search(r'caption=["\']([^"\']+)["\']', attrs_str)
         caption   = cap_match.group(1) if cap_match else None
 
         idx = len(diagrams)
-        diagrams.append({'source': source, 'caption': caption})
+        diagrams.append({
+            'source': source,
+            'caption': caption,
+            'language': language,
+            'kroki_type': KROKI_LANGUAGE_TYPES[language],
+        })
         return f'\n__MERMAID_{idx}__\n'
 
     processed = fence_re.sub(_extract, md_text)
     return processed, diagrams
+
+
+# Backwards-compatible alias — the function handled only ```mermaid fences
+# before multi-language Kroki support landed. Existing callers keep working.
+extract_mermaid_fences = extract_diagram_fences
 
 
 # ── Rendering ─────────────────────────────────────────────────────────────────
@@ -147,90 +234,123 @@ def render_diagram(
     css_path: str | None = None,
 ) -> None:
     """
-    Render a single Mermaid diagram into the document at the current position.
+    Render a single diagram into the document at the current position.
 
-    Tries mmdc first (if in PATH or forced via env var), then kroki, then
-    mermaid.ink, and finally falls back to a styled placeholder so the build
-    never hard-fails.
+    Mermaid diagrams try mmdc first (if in PATH or forced via env var), then
+    Kroki, then mermaid.ink. Every other diagram language renders via Kroki
+    only. Both paths fall back to a styled placeholder so the build never
+    hard-fails.
 
     Args:
         doc:           The python-docx Document object.
         diagram_data:  Dict with keys 'source' (str) and 'caption' (str|None).
+                       Optional 'language' and 'kroki_type' keys (added by
+                       extract_diagram_fences) select the render path;
+                       both default to 'mermaid' for older callers.
         tmp_dir:       Temporary directory for intermediate PNG files.
         mermaid_theme: mermaid.ink theme string (ignored by mmdc — use css_path).
         css_path:      Optional path to a .css file passed to mmdc --cssFile.
     """
-    source  = diagram_data['source']
-    caption = diagram_data.get('caption')
+    source     = diagram_data['source']
+    caption    = diagram_data.get('caption')
+    language   = diagram_data.get('language', 'mermaid')
+    kroki_type = diagram_data.get('kroki_type', KROKI_LANGUAGE_TYPES.get(language, language))
     render_scale = _get_mermaid_render_scale()
 
     digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
-    png_path = os.path.join(tmp_dir, f'mermaid_{digest}.png')
+    png_path = os.path.join(tmp_dir, f'{language}_{digest}.png')
     rendered = False
 
-    backend = os.environ.get('DOCX_BUILDER_MERMAID_BACKEND', 'auto').lower()
+    if language == 'mermaid':
+        backend = os.environ.get('DOCX_BUILDER_MERMAID_BACKEND', 'auto').lower()
 
-    # 1. mmdc — best quality, supports custom CSS; used when in PATH
-    if backend in ('auto', 'mmdc') and shutil.which('mmdc'):
-        _css = css_path or os.environ.get('DOCX_BUILDER_MERMAID_CSS')
-        rendered = _render_via_mmdc(
+        # 1. mmdc — best quality, supports custom CSS; used when in PATH
+        if backend in ('auto', 'mmdc') and shutil.which('mmdc'):
+            _css = css_path or os.environ.get('DOCX_BUILDER_MERMAID_CSS')
+            rendered = _render_via_mmdc(
+                source,
+                png_path,
+                css_path=_css,
+                scale=render_scale,
+            )
+
+        # 2. Kroki — primary API backend, generally more reliable
+        if not rendered and backend in ('auto', 'kroki'):
+            rendered = _render_via_kroki(source, png_path, scale=render_scale)
+
+        # 3. mermaid.ink — secondary public API fallback
+        if not rendered and backend in ('auto', 'mermaid_ink'):
+            rendered = _render_via_mermaid_ink(
+                source,
+                png_path,
+                theme=mermaid_theme,
+                scale=render_scale,
+            )
+    else:
+        # Non-mermaid languages have exactly one backend: Kroki.
+        rendered = _render_via_kroki(
             source,
             png_path,
-            css_path=_css,
-            scale=render_scale,
-        )
-
-    # 2. kroki.io — primary public API, generally more reliable
-    if not rendered and backend in ('auto', 'kroki'):
-        rendered = _render_via_kroki(source, png_path, scale=render_scale)
-
-    # 3. mermaid.ink — secondary public API fallback
-    if not rendered and backend in ('auto', 'mermaid_ink'):
-        rendered = _render_via_mermaid_ink(
-            source,
-            png_path,
-            theme=mermaid_theme,
+            diagram_type=kroki_type,
             scale=render_scale,
         )
 
     if rendered and os.path.isfile(png_path):
         _embed_image(doc, png_path, caption)
     else:
-        _embed_placeholder(doc, source, caption)
+        _embed_placeholder(doc, source, caption, language=language)
 
 
 # ── Private: rendering backends ───────────────────────────────────────────────
 
-def _render_via_kroki(source: str, output_path: str, scale: float = DIAGRAM_RENDER_SCALE_DEFAULT) -> bool:
-    """
-    Fetch a rendered PNG from the kroki.io public API.
+def _get_kroki_url() -> str:
+    """Return the Kroki base URL from the environment (default: kroki.io)."""
+    raw = os.environ.get('DOCX_BUILDER_KROKI_URL', '').strip()
+    return (raw or DEFAULT_KROKI_URL).rstrip('/')
 
-    kroki.io uses zlib compression + URL-safe base64 encoding of the diagram
-    source, which is more compact and generally more reliable than mermaid.ink.
-    Supports Mermaid and many other diagram types. No local dependencies.
+
+def _render_via_kroki(
+    source: str,
+    output_path: str,
+    diagram_type: str = 'mermaid',
+    scale: float = DIAGRAM_RENDER_SCALE_DEFAULT,
+) -> bool:
+    """
+    Fetch a rendered PNG from a Kroki server.
+
+    The diagram source is POSTed as text/plain to
+    {kroki_url}/{diagram_type}/png — the same form scripts/docx_manifest.py
+    uses, and it avoids URL-length limits that the GET encoding hits on
+    large diagrams. The endpoint defaults to the public https://kroki.io
+    API and can point at a self-hosted instance via DOCX_BUILDER_KROKI_URL.
+    Supports Mermaid and every other Kroki diagram type. No local
+    dependencies.
 
     Returns True on success, False on any network or API error.
     """
     try:
-        compressed = zlib.compress(source.encode('utf-8'), level=9)
-        encoded    = base64.urlsafe_b64encode(compressed).decode('ascii')
         params = urllib.parse.urlencode({'scale': _format_scale_query_value(scale)})
-        url = f'https://kroki.io/mermaid/png/{encoded}?{params}'
+        url = f'{_get_kroki_url()}/{diagram_type}/png?{params}'
         req = urllib.request.Request(
             url,
-            headers={'User-Agent': 'docx-builder/1.0'},
+            data=source.encode('utf-8'),
+            headers={
+                'User-Agent': 'docx-builder/1.0',
+                'Content-Type': 'text/plain; charset=utf-8',
+            },
+            method='POST',
         )
         with urllib.request.urlopen(req, timeout=20) as resp:
             content_type = resp.headers.get('Content-Type', '')
             if 'image' not in content_type:
-                print(f'  [diagrams] kroki.io returned non-image '
+                print(f'  [diagrams] Kroki returned non-image '
                       f'content-type: {content_type}')
                 return False
             with open(output_path, 'wb') as f:
                 f.write(resp.read())
         return True
     except (urllib.error.URLError, OSError) as exc:
-        print(f'  [diagrams] kroki.io render failed: {exc}')
+        print(f'  [diagrams] Kroki render failed ({diagram_type}): {exc}')
         return False
 
 
@@ -360,29 +480,36 @@ def _embed_image(doc, img_path: str, caption: str | None) -> None:
         _add_caption(doc, caption)
 
 
-def _embed_placeholder(doc, source: str, caption: str | None) -> None:
+def _embed_placeholder(doc, source: str, caption: str | None,
+                       language: str = 'mermaid') -> None:
     """
     Emit a styled warning block when diagram rendering fails.
 
-    Preserves the raw Mermaid source in a code-style paragraph so the
+    Preserves the raw diagram source in a code-style paragraph so the
     document author can see the intent. Does not raise an exception.
+    The hint text names the language and its remedy: mermaid suggests the
+    CLI install; every other language points at the Kroki endpoint.
     """
     from .xml_helpers import para_spacing, set_run_color
+
+    if language == 'mermaid':
+        hint = ('\u26a0 Diagram could not be rendered '
+                '(install @mermaid-js/mermaid-cli or check internet access)')
+    else:
+        hint = (f'\u26a0 {language} diagram could not be rendered '
+                f'(check Kroki endpoint: {_get_kroki_url()})')
 
     # Warning banner
     warn = doc.add_paragraph()
     para_spacing(warn, before=120, after=20)
-    run = warn.add_run(
-        '\u26a0 Diagram could not be rendered '
-        '(install @mermaid-js/mermaid-cli or check internet access)'
-    )
+    run = warn.add_run(hint)
     run.bold      = True
     run.italic    = True
     run.font.name = FONT_BODY
     run.font.size = Pt(9)
     set_run_color(run, DARK_NAVY)
 
-    # Mermaid source in code style with grey background
+    # Diagram source in code style with grey background
     p   = doc.add_paragraph()
     pPr = p._p.get_or_add_pPr()
     shd = OxmlElement('w:shd')

--- a/docx_builder/tests/test_diagrams.py
+++ b/docx_builder/tests/test_diagrams.py
@@ -114,3 +114,156 @@ class TestMermaidRenderScale(unittest.TestCase):
                 )
 
         self.assertTrue(ok)
+
+
+class TestDiagramFenceExtraction(unittest.TestCase):
+    def test_mermaid_fence_extracted_with_caption(self):
+        md = (
+            'Intro text.\n\n'
+            '```mermaid caption="Figure 1"\n'
+            'flowchart LR\n'
+            '    A --> B\n'
+            '```\n\n'
+            'Outro text.\n'
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertIn("__MERMAID_0__", processed)
+        self.assertNotIn("```mermaid", processed)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["caption"], "Figure 1")
+        self.assertEqual(data[0]["language"], "mermaid")
+        self.assertEqual(data[0]["kroki_type"], "mermaid")
+        self.assertIn("A --> B", data[0]["source"])
+
+    def test_kroki_language_fences_extracted(self):
+        md = (
+            "```plantuml\n@startuml\nA -> B\n@enduml\n```\n\n"
+            "```graphviz\ndigraph G { a -> b }\n```\n\n"
+            "```dot\ndigraph G { c -> d }\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(len(data), 3)
+        self.assertEqual(
+            [d["language"] for d in data], ["plantuml", "graphviz", "dot"]
+        )
+        # ```dot is an alias for the graphviz Kroki type
+        self.assertEqual(
+            [d["kroki_type"] for d in data], ["plantuml", "graphviz", "graphviz"]
+        )
+        for idx in range(3):
+            self.assertIn(f"__MERMAID_{idx}__", processed)
+
+    def test_non_diagram_fences_untouched(self):
+        # ```bash / ```yaml / ```python are ordinary code blocks and must be
+        # returned byte-for-byte — the highest-risk regression for this corpus.
+        md = (
+            "```bash\necho hello\n```\n\n"
+            "```yaml\nkey: value\n```\n\n"
+            "```python\nprint('hi')\n```\n\n"
+            "```text\nplain\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(processed, md)
+        self.assertEqual(data, [])
+
+    def test_mixed_fences_only_extract_diagrams(self):
+        md = (
+            "```bash\necho one\n```\n\n"
+            "```mermaid\nflowchart LR\n    A --> B\n```\n\n"
+            "```yaml\nkey: value\n```\n"
+        )
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["language"], "mermaid")
+        self.assertIn("```bash\necho one\n```", processed)
+        self.assertIn("```yaml\nkey: value\n```", processed)
+        self.assertNotIn("```mermaid", processed)
+
+    def test_plain_fence_untouched(self):
+        md = "```\nno info string\n```\n"
+        processed, data = diagrams.extract_diagram_fences(md)
+        self.assertEqual(processed, md)
+        self.assertEqual(data, [])
+
+    def test_extract_mermaid_fences_alias(self):
+        # Backwards-compatible alias must keep working for older callers.
+        self.assertIs(diagrams.extract_mermaid_fences, diagrams.extract_diagram_fences)
+
+
+class TestKrokiBackend(unittest.TestCase):
+    def test_kroki_posts_source_to_typed_endpoint(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["data"] = req.data
+            return _FakeResponse(b"png-bytes")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = str(Path(tmp_dir) / "diagram.png")
+            with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+                ok = diagrams._render_via_kroki(
+                    "digraph G { a -> b }",
+                    output_path,
+                    diagram_type="graphviz",
+                )
+
+        self.assertTrue(ok)
+        self.assertTrue(seen["url"].startswith("https://kroki.io/graphviz/png"))
+        self.assertEqual(seen["method"], "POST")
+        self.assertEqual(seen["data"], b"digraph G { a -> b }")
+
+    def test_kroki_url_env_override(self):
+        seen = {}
+
+        def fake_urlopen(req, timeout=0):
+            seen["url"] = req.full_url
+            return _FakeResponse(b"png-bytes")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = str(Path(tmp_dir) / "diagram.png")
+            with mock.patch.dict(
+                "os.environ",
+                {"DOCX_BUILDER_KROKI_URL": "http://127.0.0.1:8000/"},
+                clear=False,
+            ):
+                with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+                    ok = diagrams._render_via_kroki(
+                        "flowchart LR\nA-->B",
+                        output_path,
+                    )
+
+        self.assertTrue(ok)
+        self.assertTrue(seen["url"].startswith("http://127.0.0.1:8000/mermaid/png"))
+
+    def test_render_diagram_falls_back_to_placeholder_on_unreachable_kroki(self):
+        # A bogus Kroki host must never crash the build — the diagram degrades
+        # to the styled placeholder block containing the raw source.
+        import docx
+
+        doc = docx.Document()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with mock.patch.dict(
+                "os.environ",
+                {"DOCX_BUILDER_KROKI_URL": "http://nonexistent.invalid"},
+                clear=False,
+            ):
+                diagrams.render_diagram(
+                    doc,
+                    {
+                        "source": "digraph G { a -> b }",
+                        "caption": None,
+                        "language": "graphviz",
+                        "kroki_type": "graphviz",
+                    },
+                    tmp_dir,
+                )
+
+        text = "\n".join(p.text for p in doc.paragraphs)
+        self.assertIn("digraph G { a -> b }", text)
+        self.assertIn("could not be rendered", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/docx_manifest.py
+++ b/scripts/docx_manifest.py
@@ -20,6 +20,9 @@ import yaml
 TOOLKIT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST_NAME = Path("manifests") / "render-manifest.yaml"
 DEFAULT_KROKI_URL = "http://127.0.0.1:8000"
+# KEEP IN STEP with KROKI_LANGUAGE_TYPES in
+# docx_builder/src/docx_builder/diagrams.py (scripts/ is not an importable
+# package, so the mapping is duplicated there).
 SUPPORTED_DIAGRAM_TYPES = {
     "mermaid": "mermaid",
     "plantuml": "plantuml",
@@ -48,6 +51,7 @@ SUPPORTED_DIAGRAM_TYPES = {
     "excalidraw": "excalidraw",
     "bytefield": "bytefield",
     "goat": "goat",
+    "symbolator": "symbolator",
 }
 FENCE_RE = re.compile(r"```([A-Za-z0-9_-]+)[^\n]*\n(.*?)\n```", re.DOTALL)
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
Kroki multi-language diagrams on every path; logo support in docx-build-all; cover-page org-name fix; bare-name excludes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)