### PR TITLE
Do not double the copyright mark on covers

### DIFF
--- a/docx_builder/src/docx_builder/cover_page.py
+++ b/docx_builder/src/docx_builder/cover_page.py
@@ -193,7 +193,13 @@ def build_cover_footer(section, meta: dict):
         if is_url:
             run.underline = True
 
-    _footer_line(f'\u00A9{name}', bold=True)   # © OrgName
+    # The footer supplies the copyright mark, so the configured org name is
+    # expected to be the bare name. When a content repo has already baked a
+    # mark into org.yaml - easy to do and invisible in review; it took a
+    # hexdump to spot in one repo - prepending another produced a doubled
+    # mark on every cover page. Honour the mark the name already carries.
+    _mark_already_present = name.lstrip().startswith(('©', '®', '™'))
+    _footer_line(name if _mark_already_present else f'©{name}', bold=True)
     _footer_line(dept)
     _footer_line(addr1)
     _footer_line(addr2)


### PR DESCRIPTION
The cover footer prepends a copyright mark to the org name. A repo whose `org.yaml` name already started with one rendered a **doubled mark on every cover page** — and the extra character is invisible in review; it took a hexdump of `org.yaml` to find.

The footer now honours a mark the name already carries (©, ®, ™). Bare names are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)