### PR TITLE
Release: terminal editor defaults + copyright guard

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -120,6 +120,47 @@ RUN pip install --no-cache-dir --no-deps /opt/dac-toolkit/docx_builder \
 ENV DAC_TOOLKIT_HOME=/opt/dac-toolkit
 ENV PATH="/opt/dac-toolkit/scripts:${PATH}"
 
+# ── Terminal editors: vim + nano with prose-tuned system defaults ────────────
+# Documentation work in Dev Spaces happens in a browser terminal, and the base
+# image ships only vim-minimal (no syntax, no spell). Install full editors with
+# defaults that surface the characters the content repos' CI rejects (smart
+# quotes, no-break spaces, mojibake, tabs, trailing whitespace — see the
+# content repo's scripts/lint-encoding.py) while editing, instead of failing
+# the build at commit time.
+#
+# neovim is deliberately NOT installed: it is not in the free UBI9 repos
+# (verified 2026-07-21 against ubi-9-appstream/baseos repodata; it is EPEL
+# only), and bolting EPEL onto a digest-pinned, Trivy-gated image widens the
+# supply chain for no gain here. /etc/vimrc.local below is nvim-compatible;
+# a user-supplied nvim can adopt it with `source /etc/vimrc.local` in its init.
+#
+# hunspell + en-US dictionary: RHEL's stock /etc/nanorc sets
+# `set speller "hunspell"`, so without the engine nano's ^T spell check is a
+# configured-but-broken key. vim brings its own spell files (in vim-common).
+# Size: vim-enhanced+vim-common ~36 MB installed, nano ~3 MB, hunspell ~1.5 MB.
+RUN dnf install -y --nodocs vim-enhanced nano hunspell hunspell-en-US \
+    && dnf clean all
+
+# System-wide editor defaults — defaults, not mandates. Both hooks load BEFORE
+# user dotfiles (RHEL's /etc/vimrc sources /etc/vimrc.local ahead of ~/.vimrc;
+# nano reads /etc/nanorc ahead of ~/.nanorc), so personal config overrides
+# everything. The greps assert the two hooks this relies on — verified against
+# vim-common-8.2.2637 and nano-5.6.1 — so a future base/package change that
+# drops either hook fails the build here instead of silently shipping an image
+# whose editor defaults never load. yaml.nanorc fills a gap in RHEL 9's nano
+# 5.6 (upstream added YAML highlighting in 5.7); it lands in /usr/share/nano
+# where the stock /etc/nanorc wildcard include already picks it up. All three
+# files are root-owned and world-readable, which is all an arbitrary-UID
+# process needs — nothing here is written to at runtime.
+COPY .devcontainer/editor/vimrc.local /etc/vimrc.local
+COPY .devcontainer/editor/yaml.nanorc /usr/share/nano/yaml.nanorc
+COPY .devcontainer/editor/nanorc.dac-prose /tmp/nanorc.dac-prose
+RUN grep -q '^  source /etc/vimrc.local$' /etc/vimrc \
+    && grep -q '^include "/usr/share/nano/\*\.nanorc"$' /etc/nanorc \
+    && cat /tmp/nanorc.dac-prose >> /etc/nanorc \
+    && rm /tmp/nanorc.dac-prose \
+    && chmod 644 /etc/vimrc.local /etc/nanorc /usr/share/nano/yaml.nanorc
+
 # ── OpenShift arbitrary UID support ──────────────────────────────────────────
 # OpenShift runs containers with a random UID in the root group (GID 0).
 # All directories the process writes to must be group-writable.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -75,6 +75,31 @@ Dev Spaces uses `devfile.yaml` (at the repo root), not `devcontainer.json`.
 
 ---
 
+## Terminal Editors (Dev Spaces image)
+
+The Dev Spaces image (`Dockerfile.devspaces`) ships vim (full, not
+vim-minimal) and nano with system-wide prose defaults tuned for this
+workspace: the characters the content-repo CI rejects — smart quotes,
+non-breaking spaces, mojibake — are highlighted in red, tabs and trailing
+whitespace are visible, spell check is on for Markdown, and soft wrap breaks
+at word boundaries without inserting hard line breaks. YAML gets two-space
+indentation and highlighting (RHEL 9's nano predates upstream's yaml.nanorc,
+so the image carries one).
+
+These are defaults, not mandates:
+
+- vim: settings live in `/etc/vimrc.local`, sourced before `~/.vimrc`, so a
+  personal vimrc overrides anything (or `autocmd! dacprose` to drop the
+  filetype behavior wholesale).
+- nano: settings are appended to `/etc/nanorc`, read before `~/.nanorc` /
+  `~/.config/nano/nanorc`, so personal config wins. Toggle whitespace display
+  with `M-P`.
+- neovim is not in the image (not available from free UBI9 repos). A
+  user-supplied nvim can adopt the same defaults with
+  `source /etc/vimrc.local` in its init file.
+
+---
+
 ## Verify the Environment
 
 ```bash

--- a/.devcontainer/editor/nanorc.dac-prose
+++ b/.devcontainer/editor/nanorc.dac-prose
@@ -1,0 +1,44 @@
+## ----------------------------------------------------------------------------
+## dac-toolkit prose defaults — appended to /etc/nanorc by
+## .devcontainer/Dockerfile.devspaces.
+##
+## System-wide defaults only: nano reads ~/.nanorc (or ~/.config/nano/nanorc)
+## AFTER this file, so personal settings override anything here.
+##
+## RHEL's stock /etc/nanorc above already enables every syntax file in
+## /usr/share/nano (markdown, plus the yaml.nanorc this image adds) and sets
+## hunspell as the ^T spell checker; the image installs hunspell-en-US so
+## that actually works.
+##
+## NOTE: the extendsyntax rules at the bottom intentionally contain smart
+## quotes and a no-break space inside their bracket expressions — they exist
+## to paint exactly the characters the content repos' CI rejects
+## (scripts/lint-encoding.py: smart quotes, NBSP, mojibake).
+## ----------------------------------------------------------------------------
+
+## Soft-wrap long prose lines at word boundaries instead of hard-wrapping or
+## letting them run off screen. Display-only: file content is untouched.
+set softwrap
+set atblanks
+
+## Save with Unix line endings even if a pasted file arrived with CRLF.
+set unix
+
+## The Tab key inserts spaces (a real tab is a YAML syntax error and a
+## markdownlint MD010 failure). yaml.nanorc narrows this to 2 for YAML.
+set tabstospaces
+set tabsize 4
+
+## Characters used when whitespace display is toggled on with M-P:
+## tabs show as a guillemet, spaces as a middle dot.
+set whitespace "»·"
+
+## Paint the characters CI rejects, in the file types this workspace edits
+## (default covers files matching no other syntax, e.g. .qmd decks).
+extendsyntax markdown color white,red "[“”‘’ ]|â€"
+extendsyntax yaml color white,red "[“”‘’ ]|â€"
+extendsyntax default color white,red "[“”‘’ ]|â€"
+
+## Markdown: three or more trailing spaces (two is a legitimate hard break;
+## the repo linter flags three and up).
+extendsyntax markdown color ,red "   +$"

--- a/.devcontainer/editor/vimrc.local
+++ b/.devcontainer/editor/vimrc.local
@@ -1,0 +1,90 @@
+" dac-toolkit prose defaults for vim -- installed at /etc/vimrc.local by
+" .devcontainer/Dockerfile.devspaces.
+"
+" RHEL's /etc/vimrc sources this file (verified in vim-common-8.2.2637, and
+" asserted by a grep in the Dockerfile), and it runs BEFORE any ~/.vimrc, so
+" everything here is a default, not a mandate: personal dotfiles win. The
+" autocmds live in named groups so a user vimrc can inspect them
+" (:autocmd dacprose) or remove them wholesale (autocmd! dacprose).
+"
+" Why this file exists: the content repos' CI rejects invisible-character
+" defects -- smart quotes, no-break spaces, mojibake, and stray tabs/trailing
+" whitespace (scripts/lint-encoding.py and markdownlint in the content repo).
+" These settings surface those characters while editing, so the problem is
+" seen at the desk instead of failing the build at commit time.
+"
+" This file is deliberately pure ASCII. Non-ASCII display characters are
+" built with nr2char() and matched with \%uXXXX patterns, so the file parses
+" identically no matter what locale or 'encoding' vim starts with.
+
+" --- Encoding and file format ------------------------------------------------
+" The container locale is UTF-8, so 'encoding' normally already is; the guard
+" avoids a needless re-set (changing 'encoding' mid-session is discouraged).
+if &encoding !=# 'utf-8'
+  set encoding=utf-8
+endif
+set fileencodings=ucs-bom,utf-8,latin1
+
+" New files are written with Unix line endings; existing DOS files are still
+" detected and preserved rather than silently rewritten.
+set fileformats=unix,dos
+
+" --- Make invisible characters visible ----------------------------------------
+" tab   U+00BB guillemet + fill   trail   U+00B7 middle dot   nbsp   U+2423
+" extends/precedes mark text scrolled out of view on nowrap windows.
+set list
+execute 'set listchars=' .
+      \ 'tab:' . nr2char(0xbb) . '\ ,' .
+      \ 'trail:' . nr2char(0xb7) . ',' .
+      \ 'nbsp:' . nr2char(0x2423) . ',' .
+      \ 'extends:' . nr2char(0x203a) . ',' .
+      \ 'precedes:' . nr2char(0x2039)
+
+" Characters the CI encoding gate rejects, painted red in every window:
+"   u201c u201d u2018 u2019   smart quotes
+"   u00a0 u202f               no-break spaces (u00a0 also shows via listchars)
+"   ufffd                     replacement char = invalid UTF-8 upstream
+"   u200b                     zero-width space
+"   u00e2 u20ac               'a-circumflex + euro' pair = the classic
+"                             UTF-8-read-as-CP1252 mojibake lead ("a-hat-euro")
+highlight default DacLintChar ctermfg=white ctermbg=red guifg=#ffffff guibg=#cc0000
+function! s:DacLintMatch() abort
+  if exists('w:dac_lint_match')
+    return
+  endif
+  let w:dac_lint_match = matchadd('DacLintChar',
+        \ '\%u201c\|\%u201d\|\%u2018\|\%u2019\|\%u00a0\|\%u202f\|\%ufffd\|\%u200b\|\%u00e2\%u20ac')
+endfunction
+augroup dacprose_lint
+  autocmd!
+  autocmd VimEnter,WinNew * call s:DacLintMatch()
+  autocmd ColorScheme * highlight DacLintChar ctermfg=white ctermbg=red guifg=#ffffff guibg=#cc0000
+augroup END
+
+" --- Prose and YAML behaviour --------------------------------------------------
+augroup dacprose
+  autocmd!
+  " Prose: spell-check on; soft wrap at word boundaries with wrapped lines
+  " kept at their indent; never auto-insert hard line breaks while typing
+  " (textwidth=0 plus removing 't' -- repo style is one logical line per
+  " sentence/paragraph, wrapped by the terminal, not by the editor).
+  " (quarto: vim 8.2 detects .qmd as markdown via the autocmd below; newer
+  " vims have a native quarto type, so cover both.)
+  autocmd FileType markdown,text,gitcommit,quarto
+        \ setlocal spell spelllang=en_us wrap linebreak breakindent
+        \ textwidth=0 formatoptions-=t
+  " YAML: two-space indent, and the Tab key inserts spaces -- a literal tab is
+  " a YAML syntax error.
+  autocmd FileType yaml setlocal expandtab shiftwidth=2 softtabstop=2
+augroup END
+
+" --- Filetype detection ---------------------------------------------------------
+" .md and .yml/.yaml are native in vim 8.2; these fill the gaps.
+" setfiletype (not set ft=) yields to any type already detected.
+augroup dacprose_ft
+  autocmd!
+  " Quarto documents are Markdown-based; vim 8.2 predates a quarto type.
+  autocmd BufNewFile,BufRead *.qmd setfiletype markdown
+  " Devfiles named without a .yaml suffix still get YAML treatment.
+  autocmd BufNewFile,BufRead devfile,*.devfile setfiletype yaml
+augroup END

--- a/.devcontainer/editor/yaml.nanorc
+++ b/.devcontainer/editor/yaml.nanorc
@@ -1,0 +1,33 @@
+## YAML highlighting for nano 5.6 (RHEL 9). Upstream nano gained a yaml.nanorc
+## in 5.7 — one release after what RHEL 9 ships — so the dac-toolkit image
+## carries this minimal, independently written one. It is installed to
+## /usr/share/nano/, where the stock /etc/nanorc wildcard include picks it up.
+## A user's ~/.nanorc is read afterwards and can override or extend it.
+
+syntax yaml "\.ya?ml$|(^|/)\.?devfile$"
+header "^(%YAML|---([[:space:]]|$))"
+comment "#"
+
+## The Tab key indents with two spaces: a literal tab is a YAML syntax error.
+tabgives "  "
+
+## Document markers (--- / ...) and directives (%YAML, %TAG).
+color brightmagenta "^(---|\.\.\.)([[:space:]].*)?$"
+color brightmagenta "^%(YAML|TAG)([[:space:]].*)?$"
+
+## Keys, at any indent depth, including "- key:" list items.
+color green "^[[:space:]]*(-[[:space:]]+)?[^:#[:space:]][^:#]*:([[:space:]]|$)"
+
+## Scalars with special meaning to YAML parsers.
+color yellow "\<(true|false|yes|no|on|off|null)\>|(^|[[:space:]])~($|[[:space:]])"
+
+## Anchors (&name), aliases (*name), and tags (!tag, !!type).
+color cyan "(^|[[:space:]])[&*!]{1,2}[A-Za-z0-9_-]+"
+
+## Comments last among the content rules, so a "key:" inside one stays cyan.
+color cyan "(^|[[:space:]])#.*$"
+
+## Defects the content-repo CI rejects, painted so they cannot hide:
+## a literal tab (YAML syntax error) and trailing whitespace.
+color ,red "	+"
+color ,green "[[:space:]]+$"

--- a/docx_builder/src/docx_builder/cover_page.py
+++ b/docx_builder/src/docx_builder/cover_page.py
@@ -193,7 +193,13 @@ def build_cover_footer(section, meta: dict):
         if is_url:
             run.underline = True
 
-    _footer_line(f'\u00A9{name}', bold=True)   # © OrgName
+    # The footer supplies the copyright mark, so the configured org name is
+    # expected to be the bare name. When a content repo has already baked a
+    # mark into org.yaml - easy to do and invisible in review; it took a
+    # hexdump to spot in one repo - prepending another produced a doubled
+    # mark on every cover page. Honour the mark the name already carries.
+    _mark_already_present = name.lstrip().startswith(('©', '®', '™'))
+    _footer_line(name if _mark_already_present else f'©{name}', bold=True)
     _footer_line(dept)
     _footer_line(addr1)
     _footer_line(addr2)


### PR DESCRIPTION
Prose-authoring defaults for vim/nano baked into the image (visible NBSP, smart quotes, tabs, trailing whitespace - matching what lint-encoding.py rejects), plus the cover-page doubled-copyright-mark guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)