### PR TITLE
Release: starter support, dac-init phase 1, release QA

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -122,7 +122,18 @@ COPY docx_builder /opt/dac-toolkit/docx_builder
 COPY scripts /opt/dac-toolkit/scripts
 COPY presentations /opt/dac-toolkit/presentations
 COPY diagrams /opt/dac-toolkit/diagrams
+# Stock starter tree for dac-init/dac-update (conffile model — see the design
+# memo). CI stages starter-vendor/ from a pinned ref of the dac-starter repo
+# (checkout + verify + manifest; see docker-build.yml). For a LOCAL build,
+# stage it first:
+#   git clone https://github.com/KhalilGibrotha/dac-starter starter-vendor-src
+#   mkdir -p starter-vendor/files && cp -r starter-vendor-src/. starter-vendor/files/
+#   rm -rf starter-vendor/files/.git && cp starter-vendor-src/stock-hashes.json starter-vendor/
+#   python scripts/gen-stock-hashes.py --starter starter-vendor-src \
+#     --emit-manifest starter-vendor/manifest.json
+COPY starter-vendor /opt/dac-toolkit/starter
 RUN pip install --no-cache-dir --no-deps /opt/dac-toolkit/docx_builder \
+    && chmod +x /opt/dac-toolkit/scripts/dac-init \
     && chmod -R g+rx /opt/dac-toolkit
 ENV DAC_TOOLKIT_HOME=/opt/dac-toolkit
 ENV PATH="/opt/dac-toolkit/scripts:${PATH}"

--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -73,6 +73,9 @@ RUN curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v${QU
 ENV PUPPETEER_CACHE_DIR=/opt/puppeteer-cache
 ARG MERMAID_CLI_VERSION=11.16.0
 RUN npm install -g "@mermaid-js/mermaid-cli@${MERMAID_CLI_VERSION}" \
+    # markdownlint-cli2: same gate CI runs (npx would download it per run;
+    # baking it in keeps lint offline-capable and version-stable)
+    && npm install -g "markdownlint-cli2@0.23.0" \
     && npm cache clean --force \
     && chmod -R g+rx /opt/puppeteer-cache
 
@@ -102,7 +105,11 @@ RUN pip install --no-cache-dir \
     # matplotlib draws figures; pymupdf rasterizes slides for the QA gallery
     "jupyter>=1.0" \
     "matplotlib>=3.8" \
-    "pymupdf>=1.24"
+    "pymupdf>=1.24" \
+    # content repos ship an opt-in .pre-commit-config.yaml; without the binary
+    # in the image, a hook installed by `pre-commit install` fails every commit
+    # with "pre-commit not found. Did you forget to activate your virtualenv?"
+    "pre-commit>=3.6"
 
 # ── Bake the toolkit itself into the image ───────────────────────────────────
 # The image carries docx_builder (installed) plus the scripts and the

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,10 @@ name: Build and Push Dev Container Image
 
 on:
   push:
+    # A version tag builds and publishes the same image under that tag —
+    # the stable-release channel consumers pin to (alongside the digest).
+    tags:
+      - 'v*'
     branches:
       - main
     paths:
@@ -22,7 +26,7 @@ env:
   # Pinned ref of the dac-starter repo vendored into the image for
   # dac-init/dac-update. Bump deliberately when starter changes merge —
   # this is the one human step in the stock-config release path.
-  STARTER_REF: 5c5a42bc7d4c4b4b4800f8fee14cd136e688a065
+  STARTER_REF: v1.0.0
 
 jobs:
   build-and-push:
@@ -76,6 +80,7 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=${{ github.sha }}
+            type=ref,event=tag
           labels: |
             org.opencontainers.image.title=dac-toolkit
             org.opencontainers.image.description=Documentation-as-code toolchain (docx_builder, Quarto, Pandoc, Mermaid CLI, Vale) for OpenShift Dev Spaces

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,10 @@ on:
 
 env:
   IMAGE: ghcr.io/khalilgibrotha/dac-toolkit
+  # Pinned ref of the dac-starter repo vendored into the image for
+  # dac-init/dac-update. Bump deliberately when starter changes merge —
+  # this is the one human step in the stock-config release path.
+  STARTER_REF: 5c5a42bc7d4c4b4b4800f8fee14cd136e688a065
 
 jobs:
   build-and-push:
@@ -32,6 +36,28 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Checkout dac-starter (pinned ref)
+        uses: actions/checkout@v4
+        with:
+          repository: KhalilGibrotha/dac-starter
+          ref: ${{ env.STARTER_REF }}
+          path: starter-vendor-src
+
+      # Gate: the image build fails if any managed file's current hash is
+      # missing from the starter's append-only stock-hash history — the
+      # history cannot silently rot.
+      - name: Verify stock-hash history and stage the vendor tree
+        run: |
+          python3 scripts/gen-stock-hashes.py --starter starter-vendor-src --verify
+          mkdir -p starter-vendor/files
+          cp -r starter-vendor-src/. starter-vendor/files/
+          rm -rf starter-vendor/files/.git
+          cp starter-vendor-src/stock-hashes.json starter-vendor/
+          python3 scripts/gen-stock-hashes.py --starter starter-vendor-src \
+            --emit-manifest starter-vendor/manifest.json \
+            --starter-version "${STARTER_REF}" \
+            --engine-image "${IMAGE}:${GITHUB_SHA}"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,91 @@
+name: Release QA
+
+# Functional smoke tests that run INSIDE the published image — the release
+# gate between "image published" and "tag it stable". Dispatch manually after
+# a main build publishes :latest; tag the release only when this is green.
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to test"
+        default: "latest"
+        required: true
+
+jobs:
+  release-qa:
+    runs-on: ubuntu-latest
+    container: ghcr.io/khalilgibrotha/dac-toolkit:${{ inputs.image_tag }}
+    steps:
+      - name: Toolchain present and answering
+        run: |
+          set -e
+          for cmd in docx-build docx-build-all dac-init gen-stock-hashes.py \
+                     lint-frontmatter.py lint-mermaid.py lint-encoding.py \
+                     vale pandoc pre-commit markdownlint-cli2 mmdc; do
+            command -v "$cmd" >/dev/null || { echo "MISSING: $cmd"; exit 1; }
+          done
+          pandoc -v | head -1
+          vale -v
+          pre-commit --version
+          python3 -c "import docx_builder; print('docx_builder import OK')"
+
+      - name: Baked starter tree is intact and hash-history-complete
+        run: |
+          set -e
+          test -f /opt/dac-toolkit/starter/manifest.json
+          test -f /opt/dac-toolkit/starter/stock-hashes.json
+          count=$(python3 -c "import json;print(len(json.load(open('/opt/dac-toolkit/starter/manifest.json'))['files']))")
+          echo "managed files in manifest: $count"
+          test "$count" -ge 40
+          gen-stock-hashes.py --starter /opt/dac-toolkit/starter/files \
+            --history /opt/dac-toolkit/starter/stock-hashes.json --verify
+
+      - name: dac-init behaves (install, idempotence, provenance)
+        run: |
+          set -e
+          repo=$(mktemp -d); mkdir "$repo/.git"
+          dac-init --path "$repo" --dry-run | tee /tmp/dry.out
+          grep -q "already present" /tmp/dry.out
+          dac-init --path "$repo" | tee /tmp/run1.out
+          grep -qE "^[1-9][0-9]* installed" /tmp/run1.out
+          dac-init --path "$repo" | tee /tmp/run2.out
+          grep -q "^0 installed" /tmp/run2.out
+          python3 -c "
+          import json,sys
+          d=json.load(open('$repo/dac/.dac-manifest.json'))
+          assert d['files'], 'manifest recorded no files'
+          print('provenance recorded for', len(d['files']), 'files')"
+
+      - name: docx-build renders a document end to end
+        run: |
+          set -e
+          work=$(mktemp -d); cd "$work"
+          cat > doc.md <<'EOF'
+          ---
+          title: "QA Smoke Document"
+          doc_type: "reference"
+          domain: "qa"
+          department: "QA"
+          owner: "QA"
+          status: "Draft"
+          version: "0.1"
+          date: "2026-07-25"
+          author: "QA"
+          ---
+
+          # QA Smoke Document
+
+          This reference confirms the toolchain renders a document.
+
+          ## A Table
+
+          | Key | Value |
+          |---|---|
+          | works | yes |
+          EOF
+          docx-build doc.md --org /opt/dac-toolkit/starter/files/dac/org.yaml.example \
+            --output out.docx
+          test -s out.docx
+          size=$(stat -c%s out.docx)
+          echo "rendered out.docx ($size bytes)"
+          test "$size" -gt 10000

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ Thumbs.db
 
 # Claude Code
 .claude/
+
+# Staged locally for image builds (CI recreates it from the pinned starter ref)
+starter-vendor/
+starter-vendor-src/

--- a/docx_builder/src/docx_builder/batch_config.py
+++ b/docx_builder/src/docx_builder/batch_config.py
@@ -99,14 +99,22 @@ def find_config(start_dir: str, filename: str = "docx-build.yml") -> Optional[st
     """
     Walk up the directory tree from start_dir looking for filename.
 
+    At each level two locations are checked, in order: the directory itself,
+    then its dac/ subdirectory. The dac/ fallback supports content repos that
+    keep the DaC machinery in a dedicated folder instead of the repo root, so
+    a bare `docx-build-all` works in both layouts.
+
     Returns the absolute path to the config file, or None if not found before
     reaching the filesystem root.
     """
     current = os.path.abspath(start_dir)
     while True:
-        candidate = os.path.join(current, filename)
-        if os.path.isfile(candidate):
-            return candidate
+        for candidate in (
+            os.path.join(current, filename),
+            os.path.join(current, "dac", filename),
+        ):
+            if os.path.isfile(candidate):
+                return candidate
         parent = os.path.dirname(current)
         if parent == current:       # filesystem root reached
             return None
@@ -147,6 +155,12 @@ def load_config(path: Optional[str] = None) -> BatchConfig:
         raise ConfigError(f"YAML parse error in {path}: {e}") from e
 
     config_dir = os.path.dirname(path)
+    # A config living in a dac/ machinery folder anchors its relative paths at
+    # the repo root (dac/'s parent), not at dac/ itself. scan: docs/ means
+    # <repo>/docs in both layouts, so a repo can move docx-build.yml into dac/
+    # without rewriting every path in it.
+    if os.path.basename(config_dir) == "dac":
+        config_dir = os.path.dirname(config_dir)
     errors: list[str] = []
 
     # ── Required fields ───────────────────────────────────────────────────────

--- a/scripts/dac-init
+++ b/scripts/dac-init
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""dac-init — install missing DaC per-repo starting points.
+
+Copies the stock starter files (baked into the toolkit image at
+/opt/dac-toolkit/starter) into the current repo, installing ONLY what is
+missing. Existing files are never touched without --force, and --force saves
+the displaced file as <file>.orig first. Running twice is a no-op. Running it
+at all is optional — nothing in the build or lint path depends on it.
+
+    dac-init --dry-run       show what would be installed
+    dac-init                 install missing files
+    dac-init --force         also replace existing files (saves .orig)
+
+Outside a workspace:
+    podman run --rm -v "$PWD:/work:Z" -w /work \\
+      ghcr.io/khalilgibrotha/dac-toolkit:latest dac-init --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dac_common import (  # noqa: E402
+    REPO_MANIFEST, STARTER_DEFAULT, atomic_write_bytes, atomic_write_json,
+    load_json, looks_like_repo_root, managed_files, nhash,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true", help="report; write nothing")
+    ap.add_argument("--force", action="store_true",
+                    help="replace existing managed files too (saves <file>.orig)")
+    ap.add_argument("--path", default=".", help="repo root (default: cwd)")
+    ap.add_argument("--starter-dir", default=STARTER_DEFAULT, help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    repo = Path(args.path).resolve()
+    starter = Path(args.starter_dir)
+    files_dir = starter / "files"
+    manifest = load_json(starter / "manifest.json")
+
+    if not files_dir.is_dir():
+        print(f"dac-init: starter tree not found at {files_dir}\n"
+              "Run inside the dac-toolkit image, or pass --starter-dir.",
+              file=sys.stderr)
+        return 3
+    if args.path == "." and not looks_like_repo_root(repo):
+        print(f"dac-init: {repo} does not look like a repo root (no .git).\n"
+              "cd to the repo root or pass --path <dir>.", file=sys.stderr)
+        return 3
+
+    version = manifest.get("starter_version", "unknown")
+    engine = manifest.get("engine_image", "unknown")
+    print(f"dac-init (starter {version}, engine {engine})\n")
+
+    to_install, present = [], []
+    for rel in managed_files(files_dir):
+        (to_install, present)[(repo / rel).exists() and not args.force].append(rel)
+
+    for rel in to_install:
+        tag = "would install" if args.dry_run else "installed    "
+        print(f"  {tag}  {rel}")
+    for rel in present:
+        print(f"  present, skip  {rel}")
+
+    installed_hashes = {}
+    if not args.dry_run:
+        for rel in to_install:
+            src, dst = files_dir / rel, repo / rel
+            if dst.exists():                       # only reachable with --force
+                shutil.copy2(dst, dst.with_name(dst.name + ".orig"))
+                print(f"  saved          {rel}.orig")
+            atomic_write_bytes(dst, src.read_bytes())
+            installed_hashes[rel] = nhash(src)
+
+        if installed_hashes:
+            record = load_json(repo / REPO_MANIFEST)
+            record.setdefault("dac_manifest_version", 1)
+            record["starter_version"] = version
+            record["engine_image"] = engine
+            record["installed"] = date.today().isoformat()
+            record.setdefault("files", {}).update(installed_hashes)
+            atomic_write_json(repo / REPO_MANIFEST, record)
+
+    n, p = len(to_install), len(present)
+    verb = "to install" if args.dry_run else "installed"
+    print(f"\n{n} {verb}, {p} already present."
+          + (" Run without --dry-run to apply." if args.dry_run and n else ""))
+    if n and not (repo / "dac/org.yaml").exists():
+        print("Next step: copy dac/org.yaml.example to dac/org.yaml and fill it in.")
+    print("tip: run on a clean git tree, then `git diff` to review and "
+          "`git checkout --` to undo.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dac_common.py
+++ b/scripts/dac_common.py
@@ -1,0 +1,95 @@
+"""Shared plumbing for dac-init / dac-update.
+
+Design: docs/ design memo "dac-init / dac-update" (conffile hash-set model).
+A file is STOCK if its normalized hash matches any revision ever shipped;
+anything else is customized and is never overwritten. Normalization (BOM
+strip, CRLF->LF, single trailing newline) keeps Windows checkouts from
+classifying as customized. Stdlib only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+
+# The managed set: root tool files by name, plus everything under dac/ except
+# the files a team creates from examples (org identity, logo) and the record
+# this tooling itself writes. Content folders are never managed.
+MANAGED_ROOT_FILES = [
+    "devfile.yaml",
+    ".vale.ini",
+    ".markdownlint.json",
+    ".pre-commit-config.yaml",
+    ".github/workflows/lint.yml",
+    ".vscode/settings.json",
+    ".vscode/extensions.json",
+]
+MANAGED_PREFIX = "dac/"
+UNMANAGED = {
+    "dac/org.yaml",
+    "dac/logo.png",
+    "dac/.dac-manifest.json",
+}
+
+REPO_MANIFEST = "dac/.dac-manifest.json"
+STARTER_DEFAULT = os.environ.get("DAC_STARTER_DIR", "/opt/dac-toolkit/starter")
+
+
+def normalize(data: bytes) -> bytes:
+    """Normalize file content before hashing: strip UTF-8 BOM, CRLF->LF,
+    exactly one trailing newline."""
+    if data.startswith(b"\xef\xbb\xbf"):
+        data = data[3:]
+    data = data.replace(b"\r\n", b"\n")
+    return data.rstrip(b"\n") + b"\n" if data else data
+
+
+def nhash(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(normalize(path.read_bytes())).hexdigest()
+
+
+def managed_files(starter_files_dir: Path) -> list[str]:
+    """Relative paths of every managed file present in a starter tree."""
+    out = []
+    for name in MANAGED_ROOT_FILES:
+        if (starter_files_dir / name).is_file():
+            out.append(name)
+    dac_dir = starter_files_dir / "dac"
+    if dac_dir.is_dir():
+        for p in sorted(dac_dir.rglob("*")):
+            if p.is_file():
+                rel = p.relative_to(starter_files_dir).as_posix()
+                if rel not in UNMANAGED:
+                    out.append(rel)
+    return out
+
+
+def load_json(path: Path) -> dict:
+    if path.is_file():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".dac-tmp-")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_json(path: Path, obj: dict) -> None:
+    atomic_write_bytes(path, (json.dumps(obj, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def looks_like_repo_root(path: Path) -> bool:
+    return (path / ".git").exists()

--- a/scripts/gen-stock-hashes.py
+++ b/scripts/gen-stock-hashes.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Maintainer/CI tool for the starter stock-hash history and build manifest.
+
+The append-only history (stock-hashes.json, kept in the dac-starter repo) is
+what lets dac-update recognize any stock revision ever shipped. This tool
+appends current hashes, verifies the history has no gaps (the image-build
+gate), and emits the build manifest the image bakes in.
+
+    gen-stock-hashes.py --starter <dir> --append          update the history
+    gen-stock-hashes.py --starter <dir> --verify          CI gate: exit 1 on gaps
+    gen-stock-hashes.py --starter <dir> --emit-manifest manifest.json \\
+        --starter-version <ref> --engine-image <ref>      write build manifest
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dac_common import atomic_write_json, load_json, managed_files, nhash  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--starter", required=True,
+                    help="starter tree root (the repo checkout; files at its top level)")
+    ap.add_argument("--history", default=None,
+                    help="stock-hashes.json path (default: <starter>/stock-hashes.json)")
+    ap.add_argument("--append", action="store_true")
+    ap.add_argument("--verify", action="store_true")
+    ap.add_argument("--emit-manifest", default=None, metavar="PATH")
+    ap.add_argument("--starter-version", default="unknown")
+    ap.add_argument("--engine-image", default="unknown")
+    args = ap.parse_args()
+
+    root = Path(args.starter).resolve()
+    history_path = Path(args.history) if args.history else root / "stock-hashes.json"
+    history = load_json(history_path)
+    files = managed_files(root)
+    if not files:
+        print(f"gen-stock-hashes: no managed files found under {root}", file=sys.stderr)
+        return 3
+    current = {rel: nhash(root / rel) for rel in files}
+
+    if args.append:
+        added = 0
+        for rel, h in current.items():
+            known = history.setdefault(rel, [])
+            if h not in known:
+                known.append(h)
+                added += 1
+        atomic_write_json(history_path, history)
+        print(f"appended {added} new hash(es) across {len(files)} managed file(s)")
+
+    if args.verify:
+        gaps = [rel for rel, h in current.items() if h not in history.get(rel, [])]
+        if gaps:
+            print("stock-hash history is missing the CURRENT revision of:",
+                  file=sys.stderr)
+            for rel in gaps:
+                print(f"  {rel}", file=sys.stderr)
+            print("run: gen-stock-hashes.py --starter <dir> --append  "
+                  "(in the dac-starter repo) and commit stock-hashes.json",
+                  file=sys.stderr)
+            return 1
+        print(f"history OK: all {len(files)} managed files covered")
+
+    if args.emit_manifest:
+        atomic_write_json(Path(args.emit_manifest), {
+            "starter_version": args.starter_version,
+            "engine_image": args.engine_image,
+            "files": current,
+        })
+        print(f"wrote {args.emit_manifest}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-encoding.py
+++ b/scripts/lint-encoding.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Check Markdown files for encoding artifacts: mojibake, smart quotes, and
+non-breaking spaces.
+
+Mojibake is text corruption from a UTF-8/Windows-1252 round-trip (for example
+an em dash "—" becoming "â€"", or an arrow "→" becoming "â†'"). Smart quotes
+and non-breaking spaces are disallowed by the repo style guide.
+
+This is a self-contained companion to the fuller `lint-markdown.sh` in
+claude-repo-tools, so CI can run an encoding gate without the sibling repo.
+
+Fenced code blocks are skipped (front matter is scanned — a corrupted title or
+related_docs value is a real artifact). Exit codes: 0 = clean (or --no-exit),
+1 = issues found.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+# Characters a CP1252 byte 0x80-0xFF decodes to. When any of the mojibake lead
+# bytes (Ã Â â Å Æ, themselves 0xC3/0xC2/0xE2/0xC5/0xC6 -> these glyphs) is
+# followed by one of these continuation glyphs, it is mojibake — this covers
+# single- and multiply-encoded forms, including arrows (â†') and math (â‰¥).
+_CONT = bytes(range(0x80, 0x100)).decode("cp1252", errors="ignore")
+_LEADS = "ÃÂâÅÆ"
+MOJIBAKE = re.compile("[" + re.escape(_LEADS) + "][" + re.escape(_CONT) + "]")
+
+SMART_QUOTES = re.compile("[“”‘’]")
+NBSP = re.compile(" ")
+
+# U+FFFD appears when errors="replace" decodes invalid UTF-8. Flagging it
+# means invalid bytes are reported as an issue, not silently masked.
+INVALID_UTF8 = re.compile("�")
+
+CHECKS = {
+    "mojibake": MOJIBAKE,
+    "smart-quotes": SMART_QUOTES,
+    "non-breaking-space": NBSP,
+    "invalid-utf8": INVALID_UTF8,
+}
+
+SKIP_NAMES = {"README.md", "CONTRIBUTING.md", "CHANGELOG.md", "CLAUDE.md"}
+SKIP_DIRS = {".git", ".vale", ".github", "node_modules", "exports", "diagrams"}
+
+
+def iter_md(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in sorted(filenames):
+            if fn.endswith((".md", ".qmd")) and fn not in SKIP_NAMES:
+                yield os.path.join(dirpath, fn)
+
+
+def check_file(path: str) -> list[tuple[int, str, str]]:
+    issues: list[tuple[int, str, str]] = []
+    # utf-8-sig transparently strips a leading BOM (common from Windows editors).
+    with open(path, encoding="utf-8-sig", errors="replace") as fh:
+        lines = fh.readlines()
+    in_code = False
+    for i, raw in enumerate(lines, 1):
+        line = raw.rstrip("\n").rstrip("\r")
+        # Fenced code blocks may be indented up to 3 spaces.
+        if line.lstrip().startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        for name, pat in CHECKS.items():
+            if pat.search(line):
+                issues.append((i, name, line))
+    return issues
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", default=".", help="Root directory to scan")
+    ap.add_argument("--no-exit", action="store_true", help="Always exit 0 (advisory mode)")
+    args = ap.parse_args()
+
+    total = 0
+    checked = 0
+    for path in iter_md(args.path):
+        checked += 1
+        for line_no, name, line in check_file(path):
+            rel = os.path.relpath(path, args.path)
+            print(f"  {rel}:{line_no}  [{name}]")
+            print(f"    {line.strip()[:120]}")
+            total += 1
+
+    print()
+    if total == 0:
+        print(f"PASS Checked {checked} file(s). No encoding artifacts found.")
+        return 0
+    print(f"FAIL Checked {checked} file(s). {total} encoding artifact(s) found.")
+    return 0 if args.no_exit else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+lint-frontmatter.py — Validate YAML front matter in all Markdown documents.
+
+Checks:
+  - Required fields present (title, doc_type, status, version, date, author, owner)
+  - doc_type is from the approved list
+  - status is valid for the doc_type (per track)
+
+Exits 0 if all files pass, 1 if any violations are found.
+
+Usage:
+    python scripts/lint-frontmatter.py [--path docs/] [--strict]
+
+    --path    Root path to scan (default: repo root)
+    --strict  Exit non-zero on warnings as well as errors (default: errors only)
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# ── Approved values ────────────────────────────────────────────────────────────
+
+APPROVED_DOC_TYPES = {
+    "overview",
+    "gap-analysis",
+    "pattern",
+    "checklist",
+    "reference",
+    "guide",
+    "adr",
+    "proposal",
+    "standard",
+    "policy",
+    "runbook",
+    "request",
+    "release-notes",
+    "rca",
+    "spec",
+    "sad",
+    "meeting-notes",
+}
+
+# Status tracks
+STANDARD_STATUSES   = {"Draft", "In Review", "Accepted", "Retired"}
+DECISION_STATUSES   = {"Proposed", "Accepted", "Rejected", "Retired"}
+INFORMATIONAL_STATUSES = {"Informational"}
+
+# Map doc_type to its status track
+DECISION_TYPES      = {"adr", "proposal"}
+INFORMATIONAL_TYPES = {"meeting-notes"}
+
+# Informational documents (meeting notes, informal captures) have a reduced
+# required field set — no doc_type, domain, version, or owner.
+REQUIRED_FIELDS_STANDARD     = ["title", "doc_type", "domain", "department", "status", "version", "date", "author", "owner"]
+REQUIRED_FIELDS_INFORMATIONAL = ["title", "status", "date", "author"]
+
+# Files to skip entirely (no front matter expected)
+SKIP_NAMES = {"README.md", "CONTRIBUTING.md", "CHANGELOG.md", "CLAUDE.md"}
+
+# Directories to skip
+SKIP_DIRS = {
+    ".git", ".vale", "node_modules", ".github",
+    "exports", "archive", "diagrams",
+}
+
+
+# ── Front matter parser ────────────────────────────────────────────────────────
+
+_FM_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+class FrontMatterParseError(Exception):
+    """Raised when a front matter block exists but cannot be parsed."""
+
+
+def extract_front_matter(text: str) -> dict | None:
+    """Return parsed YAML front matter dict, or None if no front matter block.
+
+    Raises FrontMatterParseError if a front matter block is present but the
+    YAML inside it is malformed or is not a YAML mapping (e.g., a bare list
+    or scalar), which would cause validate() to crash on .get() calls.
+    """
+    m = _FM_PATTERN.match(text)
+    if not m:
+        return None
+    try:
+        result = yaml.safe_load(m.group(1))
+    except yaml.YAMLError as exc:
+        raise FrontMatterParseError(str(exc)) from exc
+    if result is None:
+        return {}
+    if not isinstance(result, dict):
+        raise FrontMatterParseError(
+            f"Front matter parsed as {type(result).__name__}, expected a YAML mapping"
+        )
+    return result
+
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+
+def valid_statuses_for(doc_type: str) -> set[str]:
+    if doc_type in DECISION_TYPES:
+        return DECISION_STATUSES
+    if doc_type in INFORMATIONAL_TYPES:
+        return INFORMATIONAL_STATUSES
+    return STANDARD_STATUSES
+
+
+def validate(fm: dict) -> list[tuple[str, str]]:
+    """
+    Return a list of (severity, message) tuples.
+    Severity is "ERROR" or "WARNING".
+    """
+    issues: list[tuple[str, str]] = []
+
+    # Informational documents use a reduced required-field set
+    status = str(fm.get("status", "")).strip()
+    required = (
+        REQUIRED_FIELDS_INFORMATIONAL
+        if status == "Informational"
+        else REQUIRED_FIELDS_STANDARD
+    )
+
+    # Required fields
+    for field in required:
+        if field not in fm or fm[field] is None or str(fm[field]).strip() == "":
+            issues.append(("ERROR", f"Missing required field: '{field}'"))
+
+    # doc_type (skip check for Informational docs — field is legitimately absent)
+    doc_type = str(fm.get("doc_type", "")).strip()
+    if doc_type and doc_type not in APPROVED_DOC_TYPES:
+        issues.append((
+            "ERROR",
+            f"Invalid doc_type: '{doc_type}'. Approved values: {sorted(APPROVED_DOC_TYPES)}",
+        ))
+
+    # status
+    if status and doc_type in APPROVED_DOC_TYPES:
+        allowed = valid_statuses_for(doc_type)
+        if status not in allowed:
+            issues.append((
+                "ERROR",
+                f"Invalid status: '{status}' for doc_type '{doc_type}'. "
+                f"Allowed: {sorted(allowed)}",
+            ))
+
+    # version sanity (warn if not semver-ish; "rolling" is a documented exception)
+    version = str(fm.get("version", "")).strip()
+    if version and version != "rolling" and not re.match(r"^\d+\.\d+", version):
+        issues.append(("WARNING", f"Version '{version}' does not look like a semver string (e.g., '0.1', '1.0')."))
+
+    return issues
+
+
+# ── Scanner ────────────────────────────────────────────────────────────────────
+
+def scan(root: Path, strict: bool) -> int:
+    """Walk root, validate each eligible .md file. Returns exit code."""
+    errors   = 0
+    warnings = 0
+    skipped  = 0
+    checked  = 0
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune skipped directories in-place so os.walk doesn't descend
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+
+        for filename in sorted(filenames):
+            if not filename.endswith(".md"):
+                continue
+            if filename in SKIP_NAMES:
+                skipped += 1
+                continue
+
+            filepath = Path(dirpath) / filename
+            rel      = filepath.relative_to(root)
+
+            text = filepath.read_text(encoding="utf-8")
+            try:
+                fm = extract_front_matter(text)
+            except FrontMatterParseError as exc:
+                print(f"[ERROR] {rel}: Front matter YAML is malformed — {exc}")
+                errors  += 1
+                checked += 1
+                continue
+
+            if fm is None:
+                # No front matter block at all — skip (not a formal document)
+                skipped += 1
+                continue
+
+            issues = validate(fm)
+            checked += 1
+
+            for severity, msg in issues:
+                print(f"[{severity}] {rel}: {msg}")
+                if severity == "ERROR":
+                    errors += 1
+                else:
+                    warnings += 1
+
+    # ── Summary ────────────────────────────────────────────────────────────────
+    total_issues = errors + (warnings if strict else 0)
+    status_icon  = "PASS" if total_issues == 0 else "FAIL"
+    print(
+        f"\n{status_icon} Checked {checked} file(s), skipped {skipped}. "
+        f"Errors: {errors}, Warnings: {warnings}."
+    )
+
+    return 1 if total_issues > 0 else 0
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="lint-frontmatter",
+        description="Validate YAML front matter in Markdown documents.",
+    )
+    parser.add_argument(
+        "--path",
+        default=".",
+        metavar="DIR",
+        help="Root directory to scan (default: current directory)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on warnings as well as errors",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    if not root.is_dir():
+        print(f"Error: path is not a directory: {root}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(scan(root, strict=args.strict))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lint-mermaid.py
+++ b/scripts/lint-mermaid.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Preflight Mermaid fences in formal markdown documents.
+
+This is a lightweight content check that catches fence-shape issues and a few
+house-style violations before a full DOCX render is attempted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+FRONT_MATTER_RE = re.compile(r"^---\s*\n.*?\n---\s*\n", re.DOTALL)
+SKIP_DIRS = {".git", ".github", ".vale", "archive", "exports", "diagrams", "node_modules"}
+SKIP_NAMES = {"README.md", "CLAUDE.md", "CONTRIBUTING.md", "CHANGELOG.md"}
+VALID_STARTERS = (
+    "flowchart ",
+    "sequenceDiagram",
+    "requirementDiagram",
+    "stateDiagram-v2",
+    "classDiagram",
+)
+
+
+def eligible_markdown_files(root: Path, include_templates: bool) -> list[Path]:
+    results: list[Path] = []
+    for path in sorted(root.rglob("*.md")):
+        if path.name in SKIP_NAMES:
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if not include_templates and "templates" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if FRONT_MATTER_RE.match(text):
+            results.append(path)
+    return results
+
+
+def lint_file(path: Path, root: Path) -> list[tuple[str, int, str]]:
+    issues: list[tuple[str, int, str]] = []
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    in_fence = False
+    fence_start = 0
+    fence_body: list[str] = []
+
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        if not in_fence and stripped.startswith("``` mermaid"):
+            issues.append(("ERROR", idx, "Use '```mermaid' with no space after the opening backticks."))
+            continue
+
+        if not in_fence and stripped.startswith("```mermaid"):
+            in_fence = True
+            fence_start = idx
+            fence_body = []
+            continue
+
+        if in_fence and stripped == "```":
+            content_lines = [item.strip() for item in fence_body if item.strip()]
+            if not content_lines:
+                issues.append(("ERROR", fence_start, "Mermaid fence is empty."))
+            else:
+                # The diagram type is the first non-directive line; skip any
+                # leading '%%{init}%%' directives or '%%' comments.
+                first = next((c for c in content_lines if not c.startswith("%%")), content_lines[0])
+                if first.startswith("graph "):
+                    issues.append(("ERROR", fence_start, "Use 'flowchart TD/LR' instead of deprecated 'graph TD/LR'."))
+                elif not first.startswith(VALID_STARTERS):
+                    issues.append((
+                        "WARNING",
+                        fence_start,
+                        "First Mermaid line does not match the repo's preferred diagram starters "
+                        "(flowchart, sequenceDiagram, requirementDiagram, stateDiagram-v2, classDiagram).",
+                    ))
+
+                # Semicolons break sequence/state diagram labels: ';' is a
+                # Mermaid statement separator, so it truncates the unquoted
+                # label and the renderer rejects the diagram (HTTP 400).
+                # Flowchart labels are bracket-quoted, so they are exempt.
+                # Skip '%%' comment lines, which may legitimately contain ';'.
+                if first.startswith(("sequenceDiagram", "stateDiagram")):
+                    for offset, body_line in enumerate(fence_body):
+                        if body_line.strip().startswith("%%"):
+                            continue
+                        if ";" in body_line:
+                            issues.append((
+                                "ERROR",
+                                fence_start + 1 + offset,
+                                "Semicolon in a sequence/state diagram label breaks rendering "
+                                "(';' is a Mermaid statement separator). Use a comma or dash.",
+                            ))
+            in_fence = False
+            fence_start = 0
+            fence_body = []
+            continue
+
+        if in_fence:
+            fence_body.append(line)
+
+    if in_fence:
+        issues.append(("ERROR", fence_start, "Unclosed Mermaid fence."))
+
+    if issues:
+        rel = path.relative_to(root).as_posix()
+        return [(severity, line_no, f"{rel}:{line_no}: {message}") for severity, line_no, message in issues]
+    return issues
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", default=".", help="Repo root to scan.")
+    parser.add_argument("--include-templates", action="store_true")
+    parser.add_argument("--strict-warnings", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.path).resolve()
+    files = eligible_markdown_files(root, include_templates=args.include_templates)
+
+    all_issues: list[tuple[str, int, str]] = []
+    for path in files:
+        all_issues.extend(lint_file(path, root))
+
+    errors = 0
+    warnings = 0
+    for severity, _, message in all_issues:
+        print(f"[{severity}] {message}")
+        if severity == "ERROR":
+            errors += 1
+        else:
+            warnings += 1
+
+    print(f"\nChecked {len(files)} file(s). Errors: {errors}, Warnings: {warnings}.")
+    if errors or (args.strict_warnings and warnings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Promotes develop to main for the v1.0.0 release:

- Linters on PATH, pre-commit + markdownlint in the image, dac/ config fallback (#68)
- dac-init Phase 1: stock starter vendored at dac-starter **v1.0.0**, conffile hash history + CI gate, provenance manifest
- Release QA workflow (manual gate, runs inside the image)
- v* tags publish the image under the tag

Release sequence after merge: docker-build publishes :latest → dispatch Release QA → green → tag v1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)