### PR TITLE
Cold-start findings: explain empty renders, drop the stale caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,6 @@ on.
 `dac-init`. It requires `dac/.dac-manifest.json`; if that file is missing,
 `dac-update` fails and tells you to run `dac-init` first.
 
-> `dac-update` ships in `scripts/` on this branch but had not yet reached the
-> published `:latest` image as of this writing — the `podman run` commands
-> below will work once a release ships it. Until then, run the script
-> directly from a `dac-toolkit` checkout, pointing `--starter-dir` at a
-> staged starter tree (see `CLAUDE.md`'s Testing Changes section):
-> `python scripts/dac-update --path <target-repo> --starter-dir <vendor-dir>`.
-
 ```bash
 podman run --rm -v "$PWD:/work:Z" -w /work \
   ghcr.io/khalilgibrotha/dac-toolkit:latest dac-update --dry-run

--- a/docx_builder/src/docx_builder/batch_scanner.py
+++ b/docx_builder/src/docx_builder/batch_scanner.py
@@ -103,6 +103,7 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
     valid_docs: list[ScannedDoc] = []
     warnings: list[str] = []
     no_front_matter = 0
+    any_front_matter = False
 
     for scan_root in config.scan:
         if not os.path.isdir(scan_root):
@@ -144,6 +145,8 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
                     no_front_matter += 1
                     continue
 
+                any_front_matter = True
+
                 # ── Validate required fields ───────────────────────────────
                 informational = str(meta.get('status', '')).strip() == 'Informational'
                 required = INFORMATIONAL_REQUIRED if informational else REQUIRED_FIELDS
@@ -182,10 +185,14 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
     # A repo whose Markdown has no front matter at all renders nothing. Without
     # this note the run reports "Scanned: 0" and looks broken rather than
     # explaining that the documents need front matter to be picked up.
-    if not valid_docs and no_front_matter:
+    #
+    # any_front_matter gates it separately from valid_docs: a scan can end up
+    # empty because every document was Retired or failed validation, and in
+    # those cases telling the user to add front matter would be wrong.
+    if not valid_docs and no_front_matter and not any_front_matter:
         warnings.append(
-            f"NOTE  {no_front_matter} Markdown file(s) found, none with YAML front "
-            f"matter — nothing to render. Documents need a front matter block "
+            f"NOTE  {no_front_matter} Markdown file(s) found, none with YAML front matter.\n"
+            f"      Nothing to render — documents need a front matter block "
             f"(see dac/templates/ for examples)."
         )
 

--- a/docx_builder/src/docx_builder/batch_scanner.py
+++ b/docx_builder/src/docx_builder/batch_scanner.py
@@ -12,7 +12,8 @@ Front matter requirements
 
   status must be one of the valid values in VALID_STATUSES.
 
-  Files with no front matter block are skipped silently (READMEs, etc.).
+  Files with no front matter block are skipped (READMEs, etc.). If that
+  leaves nothing to render, the scanner emits a NOTE saying so.
   Files with invalid/missing required fields emit a SKIP warning and are
   excluded from the returned list. The run continues.
 
@@ -101,6 +102,7 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
     """
     valid_docs: list[ScannedDoc] = []
     warnings: list[str] = []
+    no_front_matter = 0
 
     for scan_root in config.scan:
         if not os.path.isdir(scan_root):
@@ -135,7 +137,11 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
                 # ── Parse front matter ─────────────────────────────────────
                 meta, _ = parse_front_matter(raw)
                 if not meta:
-                    # No front matter — README or freeform note; skip silently
+                    # No front matter. READMEs and freeform notes are expected
+                    # to look like this, so it is not a warning — but count it,
+                    # so a repo whose documents all lack front matter gets told
+                    # why nothing rendered instead of a bare "Scanned: 0".
+                    no_front_matter += 1
                     continue
 
                 # ── Validate required fields ───────────────────────────────
@@ -172,5 +178,15 @@ def scan(config: BatchConfig) -> tuple[list[ScannedDoc], list[str]]:
                     version=str(meta['version']).strip(),
                     meta=meta,
                 ))
+
+    # A repo whose Markdown has no front matter at all renders nothing. Without
+    # this note the run reports "Scanned: 0" and looks broken rather than
+    # explaining that the documents need front matter to be picked up.
+    if not valid_docs and no_front_matter:
+        warnings.append(
+            f"NOTE  {no_front_matter} Markdown file(s) found, none with YAML front "
+            f"matter — nothing to render. Documents need a front matter block "
+            f"(see dac/templates/ for examples)."
+        )
 
     return valid_docs, warnings

--- a/docx_builder/tests/test_batch_scanner.py
+++ b/docx_builder/tests/test_batch_scanner.py
@@ -1,0 +1,118 @@
+"""
+tests/test_batch_scanner.py — Scanner behavior, focused on the empty-render note.
+
+Run with: python -m pytest tests/ from the docx_builder directory.
+"""
+
+import os
+import textwrap
+
+from docx_builder.batch_config import load_config
+from docx_builder.batch_scanner import scan
+
+
+NOTE_MARKER = "none with YAML front matter"
+
+
+def _repo(tmp_path, files: dict[str, str], skip_retired: bool = True):
+    """Build a minimal scannable repo and return its loaded BatchConfig."""
+    (tmp_path / "docs").mkdir(parents=True, exist_ok=True)
+    for rel, body in files.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    config = tmp_path / "docx-build.yml"
+    config.write_text(
+        "export_root: exports/\n"
+        "scan:\n  - docs/\n"
+        f"options:\n  skip_retired: {'true' if skip_retired else 'false'}\n",
+        encoding="utf-8",
+    )
+    return load_config(str(config))
+
+
+def _notes(warnings):
+    return [w for w in warnings if NOTE_MARKER in w]
+
+
+DOC_RETIRED = """
+    ---
+    title: "Old"
+    doc_type: "overview"
+    status: "Retired"
+    version: "0.1"
+    ---
+
+    # Old
+    """
+
+DOC_VALID = """
+    ---
+    title: "Current"
+    doc_type: "overview"
+    status: "Draft"
+    version: "0.1"
+    ---
+
+    # Current
+    """
+
+DOC_MISSING_FIELDS = """
+    ---
+    title: "Incomplete"
+    ---
+
+    # Incomplete
+    """
+
+NO_FRONT_MATTER = """
+    # Just a note
+
+    No front matter here.
+    """
+
+
+def test_note_fires_when_nothing_has_front_matter(tmp_path):
+    config = _repo(tmp_path, {"docs/notes.md": NO_FRONT_MATTER})
+    docs, warnings = scan(config)
+    assert docs == []
+    assert len(_notes(warnings)) == 1
+
+
+def test_note_silent_when_a_retired_doc_supplied_front_matter(tmp_path):
+    # Empty render, but front matter exists — telling the user to add it is wrong.
+    config = _repo(tmp_path, {
+        "docs/notes.md": NO_FRONT_MATTER,
+        "docs/old.md": DOC_RETIRED,
+    })
+    docs, warnings = scan(config)
+    assert docs == []
+    assert _notes(warnings) == []
+
+
+def test_note_silent_when_front_matter_failed_validation(tmp_path):
+    # The doc is skipped for missing required fields, not for lacking front matter.
+    config = _repo(tmp_path, {
+        "docs/notes.md": NO_FRONT_MATTER,
+        "docs/incomplete.md": DOC_MISSING_FIELDS,
+    })
+    docs, warnings = scan(config)
+    assert docs == []
+    assert _notes(warnings) == []
+    assert any("missing front matter" in w for w in warnings)
+
+
+def test_note_silent_when_something_rendered(tmp_path):
+    config = _repo(tmp_path, {
+        "docs/notes.md": NO_FRONT_MATTER,
+        "docs/current.md": DOC_VALID,
+    })
+    docs, warnings = scan(config)
+    assert len(docs) == 1
+    assert _notes(warnings) == []
+
+
+def test_note_spans_two_lines(tmp_path):
+    config = _repo(tmp_path, {"docs/notes.md": NO_FRONT_MATTER})
+    _, warnings = scan(config)
+    assert "\n" in _notes(warnings)[0]


### PR DESCRIPTION
Two of the five findings from the cold-start docs-as-test pass. The other three are fixed in [dac-starter#4](https://github.com/KhalilGibrotha/dac-starter/pull/4); one needs a release and is described below.

## Silent empty render (MAJOR)

A repo whose Markdown has no front matter rendered nothing and reported `Scanned: 0` with no explanation — the realistic case for a team adopting the engine with existing legacy content, and indistinguishable from a broken tool. Reproduced from a clean repo with one front-matter-less document.

`batch_scanner` now counts files skipped for missing front matter and, **only when that leaves nothing to render**, emits:

```
NOTE  1 Markdown file(s) found, none with YAML front matter — nothing to render.
      Documents need a front matter block (see dac/templates/ for examples).
```

Deliberately not a per-file warning: READMEs and freeform notes are expected to lack front matter, and warning on each would be noise in every healthy repo.

## Stale `dac-update` caveat (MAJOR)

The README warned that `dac-update` "had not yet reached the published `:latest` image" and pointed readers at a maintainer-only workaround — directly above the `podman run` command that now works, since the image was rebuilt with it. Removed.

## Verification note worth recording

While testing this I found that `pip install --force-reinstall` from a read-only bind mount **fails silently inside the container**, so runs that appear to test modified source actually test the baked-in package. Re-verified everything by mounting the source on `PYTHONPATH` instead: the NOTE fires correctly, and both suites pass against the modified source (25 docx_builder + 23 scripts).

## Remaining finding — needs a release, not code

Templates on dac-starter's `main` drifted from the `v1.0.0` tag this image vendors (commit `c67d786` stripped trailing whitespace in a markdownlint cleanup). A repo cloned from `main` therefore shows three templates as `keep+new` on its first `dac-update` — the tooling is correct, the pinned stock is stale. Fix is a dac-starter release plus a `STARTER_REF` bump here, which also yields the first genuine `replace` case for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)