### PR TITLE
Vendor dac-starter v1.1.0

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ env:
   # Pinned ref of the dac-starter repo vendored into the image for
   # dac-init/dac-update. Bump deliberately when starter changes merge —
   # this is the one human step in the stock-config release path.
-  STARTER_REF: v1.0.0
+  STARTER_REF: v1.1.0
 
 jobs:
   build-and-push:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - main
 
-env:
-  STARTER_REF: v1.0.0
-
 jobs:
   tests:
     name: Python tests

--- a/.github/workflows/pr-image-build.yml
+++ b/.github/workflows/pr-image-build.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-image-build.yml"
 
 env:
-  STARTER_REF: v1.0.0
+  STARTER_REF: v1.1.0
 
 jobs:
   image-build:


### PR DESCRIPTION
Closes the template-drift finding from the cold-start pass.

The image vendored `v1.0.0` while dac-starter's `main` had moved on, so a repo cloned from the template showed three templates as `keep+new` ("locally customized") on its first `dac-update`. The tooling was right; the pinned stock was stale.

[dac-starter v1.1.0](https://github.com/KhalilGibrotha/dac-starter/releases/tag/v1.1.0) carries the followable quick starts, the `dac-init` provenance step, and no committed `org.yaml` placeholder. Its append-only hash history retains every earlier revision, so a repo still holding v1.0.0 content now gets a genuine `replace` — the one `dac-update` outcome no QA pass could exercise, since only one starter revision had ever shipped.

Also drops the `STARTER_REF` left behind in `pr-checks.yml`, dead since the image build moved to its own paths-filtered workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)