### PR TITLE
Tolerate a UTF-8 BOM ahead of front matter

### DIFF
--- a/docx_builder/src/docx_builder/metadata.py
+++ b/docx_builder/src/docx_builder/metadata.py
@@ -91,12 +91,18 @@ def parse_front_matter(raw_text: str) -> tuple[dict, str]:
         (meta, body_md) where meta is a dict and body_md is the markdown
         content after the front matter block.
     """
-    fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', raw_text, re.DOTALL)
+    # A UTF-8 BOM ahead of the opening --- defeats this match, which made the
+    # document invisible to the builder with no diagnostic. Windows editors and
+    # PowerShell's Set-Content -Encoding utf8 write one by default, so strip it
+    # instead of silently skipping the file.
+    text = raw_text.lstrip('﻿')
+
+    fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', text, re.DOTALL)
     if fm_match:
         meta    = yaml.safe_load(fm_match.group(1)) or {}
-        body_md = raw_text[fm_match.end():]
+        body_md = text[fm_match.end():]
         return meta, body_md
-    return {}, raw_text
+    return {}, text
 
 
 def extract_headings(body_md: str) -> list[tuple]:

--- a/docx_builder/tests/test_metadata.py
+++ b/docx_builder/tests/test_metadata.py
@@ -128,3 +128,11 @@ def test_extract_headings_strips_whitespace():
     headings = extract_headings(body)
     # Text is numbered; verify the title portion (after the em dash) is trimmed
     assert headings[0][1].endswith("Heading with extra space")
+
+
+def test_parse_front_matter_tolerates_utf8_bom():
+    """A BOM ahead of --- used to hide the document from the builder entirely."""
+    raw = '﻿' + '---\ntitle: "BOM Doc"\nstatus: "Draft"\nversion: "0.1"\n---\n\n# BOM Doc\n'
+    meta, body = parse_front_matter(raw)
+    assert meta["title"] == "BOM Doc"
+    assert body.lstrip().startswith("# BOM Doc")


### PR DESCRIPTION
Found while testing the PowerShell path during the cold-start re-test.

A UTF-8 BOM before the opening `---` defeated the front-matter regex, so the document parsed as having no front matter at all. The builder then reported `Scanned: 0` and rendered nothing, with no message identifying the file — the same silent-empty-render class the scanner NOTE was added to address, reachable a different way.

The trigger is ordinary Windows editing: PowerShell 5.1's `Set-Content -Encoding utf8` writes a BOM by default, and several Windows editors do too. I hit it by accident while scripting a test edit.

```
without BOM -> parsed
with BOM    -> not parsed
```

Stripping the BOM matches what `dac_common.normalize` already does when hashing managed files, so both halves of the toolkit now treat it as noise rather than content. Regression test added; 31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)