### PR TITLE
Vendor dac-starter v1.1.1

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ env:
   # Pinned ref of the dac-starter repo vendored into the image for
   # dac-init/dac-update. Bump deliberately when starter changes merge —
   # this is the one human step in the stock-config release path.
-  STARTER_REF: v1.1.0
+  STARTER_REF: v1.1.1
 
 jobs:
   build-and-push:

--- a/.github/workflows/pr-image-build.yml
+++ b/.github/workflows/pr-image-build.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-image-build.yml"
 
 env:
-  STARTER_REF: v1.1.0
+  STARTER_REF: v1.1.1
 
 jobs:
   image-build:


### PR DESCRIPTION
Ships the Dev Spaces fixes to the image.

[dac-starter v1.1.1](https://github.com/KhalilGibrotha/dac-starter/releases/tag/v1.1.1) moves the Vale vocabulary to `config/vocabularies/`, where Vale 3.15.1 reads it. It shipped only in the legacy `Vocab/` location, so the devfile's `lint-prose` task failed on every freshly adopted repo — the bare-command Dev Spaces path, which is exactly how the first outside team will use this. It also carries the PowerShell `dac` wrapper and the note that builds key off `version:` rather than file content.

Existing adopters reconcile cleanly. Verified the real sequence end to end: adopt at v1.1.0, then `dac-update` installs the new vocabulary location, removes the two unmodified legacy files, and `vale` runs clean afterward. That is the obsolete-file reconciliation path running for the first time against a genuine rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)