### PR TITLE
Correct the Vale style-package paths for the dac/ layout

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -105,9 +105,11 @@ commands:
         if [ -d /opt/vale-styles ]; then
           for repo in /projects/*/; do
             if [ -f "$repo/.vale.ini" ]; then
-              mkdir -p "$repo/.vale/styles"
-              cp -rn /opt/vale-styles/* "$repo/.vale/styles/" 2>/dev/null || true
-              echo "=== Vale styles copied to $repo ==="
+              sp=$(grep -m1 StylesPath "$repo/.vale.ini" | cut -d= -f2 | tr -d " ")
+              sp=${sp:-.vale/styles}
+              mkdir -p "$repo/$sp"
+              cp -rn /opt/vale-styles/* "$repo/$sp/" 2>/dev/null || true
+              echo "=== Vale styles copied to $repo$sp ==="
             fi
           done
         fi

--- a/scripts/vale-bootstrap.sh
+++ b/scripts/vale-bootstrap.sh
@@ -3,7 +3,9 @@
 #
 # During docker build, vale sync downloads RedHat + write-good packages into
 # /opt/vale-styles.  At container start this script copies them into the
-# workspace's .vale/styles/ directory so Vale works fully offline.
+# workspace's styles directory so Vale works fully offline. The destination
+# is read from the repo's own .vale.ini StylesPath, so this works for the
+# canonical dac/vale/styles layout and for legacy .vale/styles alike.
 #
 # Usage:
 #   bash vale-bootstrap.sh [CONTENT_DIR]
@@ -25,10 +27,17 @@ if [[ ! -d "$PREBAKED" ]]; then
     exit 0
 fi
 
-mkdir -p "$CONTENT_DIR/.vale/styles"
+# Resolve StylesPath from .vale.ini rather than assuming a layout. Copying to
+# the wrong path leaves BasedOnStyles unresolvable in an offline workspace,
+# which surfaces as a confusing "style not found" rather than a missing file.
+STYLES_REL="$(sed -n 's/^[[:space:]]*StylesPath[[:space:]]*=[[:space:]]*//p'     "$CONTENT_DIR/.vale.ini" | head -n 1 | tr -d '')"
+STYLES_REL="${STYLES_REL:-.vale/styles}"
+STYLES_DIR="$CONTENT_DIR/$STYLES_REL"
+
+mkdir -p "$STYLES_DIR"
 if [ -n "$(ls -A "$PREBAKED")" ]; then
-    cp -rn "$PREBAKED"/* "$CONTENT_DIR/.vale/styles/"
-    echo "vale-bootstrap: pre-baked styles copied to $CONTENT_DIR/.vale/styles/"
+    cp -rn "$PREBAKED"/* "$STYLES_DIR/"
+    echo "vale-bootstrap: pre-baked styles copied to $STYLES_DIR/"
 else
     echo "vale-bootstrap: no styles found in $PREBAKED — skipping"
 fi

--- a/vale/README.md
+++ b/vale/README.md
@@ -20,16 +20,46 @@ Markdown-based documentation repositories.
 
 ## Usage
 
-Copy the `DocOps/` folder into your content repo's `.vale/styles/` directory,
-then reference it in `.vale.ini`:
+Adopted repositories get this for free — `dac-init` installs `DocOps/` at
+`dac/vale/styles/DocOps/` along with a working `.vale.ini`. The rest of this
+section is for anyone wiring it up by hand or extending it.
+
+The canonical layout puts the styles path under `dac/`:
 
 ```ini
-StylesPath = .vale/styles
+StylesPath = dac/vale/styles
 MinAlertLevel = suggestion
+Vocab = <YourVocabName>
 
 [*.md]
 BasedOnStyles = DocOps, RedHat, write-good
 ```
+
+### Where the pieces live
+
+```text
+dac/vale/styles/
+|-- DocOps/                        committed - the house style, this package
+|-- config/
+|   `-- vocabularies/
+|       `-- <YourVocabName>/       committed - your terms
+|           |-- accept.txt
+|           `-- reject.txt
+|-- RedHat/                        gitignored - vale sync regenerates
+|-- write-good/                    gitignored - vale sync regenerates
+`-- ai-tells/                      gitignored - vale sync regenerates
+```
+
+**Vocabularies belong at `<StylesPath>/config/vocabularies/<Name>/`**, where
+`<Name>` is the folder name that `Vocab =` refers to in `.vale.ini`. Vale 2
+read them from `<StylesPath>/Vocab/<Name>/`. That path is dead in Vale 3:
+entries placed there are ignored with no error, and a repo carrying both
+locations drifts apart silently. Migrating an older repo means moving the
+folder and deleting the old one.
+
+Packages named in `Packages =` are downloaded by `vale sync` into the styles
+path. Gitignore those and commit only what you author: the house style and
+your vocabularies.
 
 ## Customizing for Your Environment
 

--- a/vale/README.md
+++ b/vale/README.md
@@ -28,12 +28,18 @@ The canonical layout puts the styles path under `dac/`:
 
 ```ini
 StylesPath = dac/vale/styles
-MinAlertLevel = suggestion
+MinAlertLevel = warning
 Vocab = <YourVocabName>
+Packages = RedHat, write-good
 
 [*.md]
 BasedOnStyles = DocOps, RedHat, write-good
 ```
+
+Every style in `BasedOnStyles` must be present in the styles path. `DocOps`
+is committed; the rest are named in `Packages` and fetched by `vale sync`.
+The starter ships a fuller version of this file, including the `ai-tells`
+package — take that as the working reference rather than this minimum.
 
 ### Where the pieces live
 
@@ -52,7 +58,7 @@ dac/vale/styles/
 
 **Vocabularies belong at `<StylesPath>/config/vocabularies/<Name>/`**, where
 `<Name>` is the folder name that `Vocab =` refers to in `.vale.ini`. Vale 2
-read them from `<StylesPath>/Vocab/<Name>/`. That path is dead in Vale 3:
+reads them from `<StylesPath>/Vocab/<Name>/`. That path is dead in Vale 3:
 entries placed there are ignored with no error, and a repo carrying both
 locations drifts apart silently. Migrating an older repo means moving the
 folder and deleting the old one.


### PR DESCRIPTION
`vale/README.md` still described the pre-`dac/` layout: it told adopters to copy `DocOps/` into `.vale/styles/` and set `StylesPath = .vale/styles`. Neither matches what `dac-init` installs or what the starter ships, so anyone following it by hand built a configuration the tooling does not produce.

Now documents:

- the canonical `StylesPath = dac/vale/styles`, with a note that adopted repos get this from `dac-init` and this section is for hand-wiring or extending
- a tree separating **committed** directories (the house `DocOps` style, your vocabularies) from the ones `vale sync` regenerates and gitignores
- that vocabularies belong at `<StylesPath>/config/vocabularies/<Name>/`, where `<Name>` is what `Vocab =` references

It calls out the dead Vale 2 `Vocab/<Name>/` path explicitly. Entries there are ignored with **no error**, so the file looks maintained while doing nothing — that is how the architecture-docs repo carried two copies and let one fall 35 words behind, and how a fresh starter repo hit `'config/vocabularies/...' directory does not exist` during the Dev Spaces cold-start test.

Companion PRs carry the same information to the other two audiences: [dac-starter#7](https://github.com/KhalilGibrotha/dac-starter/pull/7) for adopters and architecture-docs#174 for that repo's own contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)