### PR TITLE
Release QA deck gate, LF entry points, and a working local-build recipe

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -48,30 +48,47 @@ Dev Spaces uses `devfile.yaml` (at the repo root), not `devcontainer.json`.
 
 **Air-gapped / pre-built image (recommended for production):**
 
+These commands are **bash** — run them in WSL, Git Bash, or a Linux shell, not
+PowerShell. (Podman itself is the exception: on Windows run `podman build` from
+PowerShell, since Git Bash rewrites container paths.)
+
 1. Stage the pinned starter vendor tree. CI does this before every build, so a
-   bare `podman build` fails at `COPY starter-vendor`. Use the `STARTER_REF`
-   pinned in `.github/workflows/docker-build.yml`:
+   bare `podman build` fails at `COPY starter-vendor`.
+
+   Read the ref from the workflow rather than typing a version — this pin moves
+   whenever a new starter ships, and a hard-coded tag here silently vendors the
+   wrong one:
 
    ```bash
-   git clone --depth 1 --branch v1.1.1 \
+   STARTER_REF=$(sed -n 's/^[[:space:]]*STARTER_REF:[[:space:]]*//p' \
+     .github/workflows/docker-build.yml | head -n 1 | tr -d '"'"'"'"')
+   echo "vendoring starter $STARTER_REF"
+
+   git clone --depth 1 --branch "$STARTER_REF" \
      https://github.com/KhalilGibrotha/dac-starter starter-vendor-src
    python3 scripts/gen-stock-hashes.py --starter starter-vendor-src --verify
+   rm -rf starter-vendor
    mkdir -p starter-vendor/files
    cp -r starter-vendor-src/. starter-vendor/files/
    rm -rf starter-vendor/files/.git
    cp starter-vendor-src/stock-hashes.json starter-vendor/
    python3 scripts/gen-stock-hashes.py --starter starter-vendor-src \
      --emit-manifest starter-vendor/manifest.json \
-     --starter-version v1.1.1 --engine-image dac-toolkit:local
+     --starter-version "$STARTER_REF" --engine-image dac-toolkit:local
    ```
 
-2. Build — on Windows, from a `git archive` staging directory, never the
-   worktree. A worktree COPY bakes checkout artifacts into the image: a CRLF
-   shebang on `dac-init` shipped exactly this way and broke it inside the
-   image, while CI, building from a Linux checkout, stayed green.
+2. Build from a `git archive` staging directory, never the worktree. A worktree
+   COPY bakes checkout artifacts into the image: a CRLF shebang on `dac-init`
+   shipped exactly this way and broke it inside the image, while CI, building
+   from a Linux checkout, stayed green.
+
+   The staging directory is recreated rather than reused. `tar -x` only
+   overwrites paths present in the new archive, so a file deleted since the
+   last build would otherwise survive in `/tmp/ctx` and be baked in again:
 
    ```bash
-   mkdir -p /tmp/ctx && git archive HEAD | tar -x -C /tmp/ctx
+   rm -rf /tmp/ctx && mkdir -p /tmp/ctx
+   git archive HEAD | tar -x -C /tmp/ctx
    cp -r starter-vendor /tmp/ctx/
    podman build -f .devcontainer/Dockerfile.devspaces \
      -t <your-registry>/dac-toolkit:latest /tmp/ctx

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -48,17 +48,44 @@ Dev Spaces uses `devfile.yaml` (at the repo root), not `devcontainer.json`.
 
 **Air-gapped / pre-built image (recommended for production):**
 
-1. Build the Dev Spaces-specific image and push to your internal registry:
+1. Stage the pinned starter vendor tree. CI does this before every build, so a
+   bare `podman build` fails at `COPY starter-vendor`. Use the `STARTER_REF`
+   pinned in `.github/workflows/docker-build.yml`:
 
    ```bash
-   podman build -f .devcontainer/Dockerfile.devspaces \
-     -t <your-registry>/dac-toolkit:latest .
-   podman push <your-registry>/dac-toolkit:latest
+   git clone --depth 1 --branch v1.1.1 \
+     https://github.com/KhalilGibrotha/dac-starter starter-vendor-src
+   python3 scripts/gen-stock-hashes.py --starter starter-vendor-src --verify
+   mkdir -p starter-vendor/files
+   cp -r starter-vendor-src/. starter-vendor/files/
+   rm -rf starter-vendor/files/.git
+   cp starter-vendor-src/stock-hashes.json starter-vendor/
+   python3 scripts/gen-stock-hashes.py --starter starter-vendor-src \
+     --emit-manifest starter-vendor/manifest.json \
+     --starter-version v1.1.1 --engine-image dac-toolkit:local
    ```
 
-2. Edit `devfile.yaml` — replace the `image:` line in the `tools` component
-3. Remove or comment out the `install-tools` postStart event (tools are already in the image)
-4. Add your content repos to the `projects:` block in `devfile.yaml`
+2. Build — on Windows, from a `git archive` staging directory, never the
+   worktree. A worktree COPY bakes checkout artifacts into the image: a CRLF
+   shebang on `dac-init` shipped exactly this way and broke it inside the
+   image, while CI, building from a Linux checkout, stayed green.
+
+   ```bash
+   mkdir -p /tmp/ctx && git archive HEAD | tar -x -C /tmp/ctx
+   cp -r starter-vendor /tmp/ctx/
+   podman build -f .devcontainer/Dockerfile.devspaces \
+     -t <your-registry>/dac-toolkit:latest /tmp/ctx
+   ```
+
+3. Validate before pushing: run the Release QA steps
+   (`.github/workflows/qa.yml`) against the built tag — toolchain presence
+   including quarto and render-decks.sh, a deck render, the starter-tree
+   verify, dac-init idempotence, and a docx render.
+
+4. Push, then edit `devfile.yaml` — replace the `image:` line in the `tools`
+   component
+5. Remove or comment out the `install-tools` postStart event (tools are already in the image)
+6. Add your content repos to the `projects:` block in `devfile.yaml`
 
 ---
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,10 @@
 *.py text eol=lf
 Makefile text eol=lf
 Dockerfile* text eol=lf
+
+# The extensionless CLI entry points are Python scripts too. Without this a
+# Windows checkout gives them CRLF, and an image built from that worktree
+# ships a broken shebang ("env: 'python3\r'") while CI, building from a
+# Linux checkout, stays green. Found by building locally and running QA.
+scripts/dac-init text eol=lf
+scripts/dac-update text eol=lf

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -32,12 +32,20 @@ jobs:
 
       - name: Deck toolchain renders a PowerPoint end to end
         run: |
-          set -e
+          # pipefail matters here: without it `quarto check | tail` reports
+          # tail's exit status, which always succeeds, so a broken Quarto would
+          # sail through this gate unnoticed.
+          set -eo pipefail
           quarto check 2>&1 | tail -3
-          work=$(mktemp -d); cd "$work"
-          printf -- '---\ntitle: "QA Deck"\nformat: pptx\n---\n\n## One slide\n\n- renders\n' > deck.qmd
-          quarto render deck.qmd --to pptx
-          python3 -c "import zipfile; z=zipfile.ZipFile('deck.pptx'); assert z.testzip() is None; assert 'ppt/presentation.xml' in z.namelist(); print('deck.pptx intact')"
+
+          # Exercise the SHIPPED entry point rather than calling quarto by
+          # hand. Rendering a throwaway deck proved only that quarto works --
+          # render-decks.sh itself could be broken and this gate stayed green,
+          # which is the gap this job exists to close. --smoke renders the
+          # bundled example through the real script and asserts a figure image
+          # embedded, so a broken wrapper, a bad bundled path, or a broken
+          # Jupyter/matplotlib integration all fail here.
+          render-decks.sh --smoke
 
       - name: Baked starter tree is intact and hash-history-complete
         run: |

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -21,13 +21,23 @@ jobs:
           set -e
           for cmd in docx-build docx-build-all dac-init dac-update gen-stock-hashes.py \
                      lint-frontmatter.py lint-mermaid.py lint-encoding.py \
-                     vale pandoc pre-commit markdownlint-cli2 mmdc; do
+                     vale pandoc pre-commit markdownlint-cli2 mmdc \
+                     quarto render-decks.sh; do
             command -v "$cmd" >/dev/null || { echo "MISSING: $cmd"; exit 1; }
           done
           pandoc -v | head -1
           vale -v
           pre-commit --version
           python3 -c "import docx_builder; print('docx_builder import OK')"
+
+      - name: Deck toolchain renders a PowerPoint end to end
+        run: |
+          set -e
+          quarto check 2>&1 | tail -3
+          work=$(mktemp -d); cd "$work"
+          printf -- '---\ntitle: "QA Deck"\nformat: pptx\n---\n\n## One slide\n\n- renders\n' > deck.qmd
+          quarto render deck.qmd --to pptx
+          python3 -c "import zipfile; z=zipfile.ZipFile('deck.pptx'); assert z.testzip() is None; assert 'ppt/presentation.xml' in z.namelist(); print('deck.pptx intact')"
 
       - name: Baked starter tree is intact and hash-history-complete
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,27 @@
 The engine of the docs-as-code system: a self-contained container image that
 content repos consume via devfile and CI. Content repos never clone this repo.
 
+## Where Commands Run
+
+**Container lane, and this repo builds the container.** Tests, renders, and
+`dac-init` smoke runs go inside the image, not on the Windows host. Build and
+run from **PowerShell** — Git Bash rewrites container mount paths and fails
+with a misleading "workdir does not exist".
+
+Scripts under `scripts/` execute in a Linux image. Author and test them there:
+a CRLF ending or a lost exec bit is invisible on Windows and fatal in the
+image, and `.gitattributes` cannot rescue a file git already classified as
+binary (check `git ls-files --eol`, treat `i/-text` as the real signal).
+
+**This is a PUBLIC repo.** No organization identifiers in files, commit
+messages, or PR text. A session rooted in the private `architecture-docs` can
+edit here freely, because the permission scope spans all of `E:\dev` — so that
+constraint must be held deliberately rather than inferred from surroundings.
+
+**Sibling repos** (full map in the global instructions): `E:\dev\dac-starter`
+is the vendored starter, also public; `E:\dev\architecture-docs` is the private
+production consumer of this image.
+
 ## Architecture
 
 - **Image** (`ghcr.io/khalilgibrotha/dac-toolkit`): docx_builder installed as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,12 @@ constraint must be held deliberately rather than inferred from surroundings.
 is the vendored starter, also public; `E:\dev\architecture-docs` is the private
 production consumer of this image.
 
+**Root cross-repo sessions at `E:\dev\architecture-docs`.** The three release as
+a set — starter tag, `STARTER_REF` bump here, image rebuild, consumer picks it
+up — and that order only reads correctly from the consumer end. A session
+started here can reach the siblings (`.claude/settings.local.json` lists them),
+so this is about where the work is driven from, not what is reachable.
+
 ## Architecture
 
 - **Image** (`ghcr.io/khalilgibrotha/dac-toolkit`): docx_builder installed as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,34 @@ content repos consume via devfile and CI. Content repos never clone this repo.
   repo's root or in its `dac/` folder; a `dac/` config anchors relative paths
   at the repo root.
 
+## Two Different Devcontainers
+
+`.devcontainer/` here is for **developing the engine**: it builds
+`.devcontainer/Dockerfile` through compose, mounts this repo at `/workspace`,
+runs `network_mode: none`, and editable-installs docx_builder.
+
+Content repos carry a different one that **consumes the published image** —
+no build, no compose, just `image:` plus the extension list. Do not copy this
+repo's devcontainer into a content repo; they solve opposite problems.
+
+`.devcontainer/devcontainer.json` is not in `MANAGED_ROOT_FILES`, so `dac-init`
+does not install the content-repo devcontainer into an existing repository. It
+arrives only by templating from dac-starter. Adding it to the managed set is a
+deliberate change: it puts the file under `dac-update` control and requires a
+`stock-hashes.json` append.
+
+**Known defect — `scripts/vale-bootstrap.sh` has CRLF line endings.** The
+`StylesPath` extraction fails under the container's bash, so it silently falls
+back to the legacy `.vale/styles` path and reports success, leaving styles
+where Vale will not look. `/opt/vale-styles` also bakes only RedHat and
+write-good, not the `ai-tells` package content repos declare. Until both are
+fixed, content repos sync Vale styles themselves rather than calling this
+script.
+
+Shell scripts in this repo run on Linux. Author and edit them in the Linux lane
+— CRLF endings and lost exec bits are invisible on Windows and fatal in the
+image.
+
 ## Key Constraints
 
 1. **Public repo.** No organization identifiers anywhere — files, commit


### PR DESCRIPTION
## What

Hardens the release path around the deck toolchain, and documents what a local
image build actually requires. Six commits: the Release QA deck gate, LF
attributes for the extensionless CLI entry points, the working local-build
recipe, and CLAUDE.md notes on the devcontainer split and cross-repo session
layout.

## Why

A consuming workspace reported `quarto: command not found` while every gate
here was green. The image was fine — the gap was that Release QA never checked
quarto or render-decks.sh, so a broken deck toolchain could not fail the gate.
Building the image locally to prove that exposed two more defects:

- `.gitattributes` covered `*.py` but not `scripts/dac-init` / `scripts/dac-update`,
  so a Windows-worktree build ships a CRLF shebang (`env: 'python3\r'`) that CI,
  building from a Linux checkout, never sees.
- The devcontainer README's air-gapped build instructions predate the
  starter-vendor staging step and fail at `COPY starter-vendor`.

## Verification

Built the image locally from a `git archive` context with the vendored starter
staged per the CI recipe, then ran the full Release QA sequence inside it —
toolchain presence (15 tools), a minimal quarto→pptx render with package
verification, the starter-tree hash verify (47 files), dac-init idempotence,
and an end-to-end docx render. All pass. A real deck from a consuming content
repo rendered against its branded reference template inside the image.

## Follow-ups

- Dispatch Release QA against the next published :latest so the new deck gate
  runs on a real build before the next stable tag.
