### PR TITLE
Bump the five pinned actions together

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Hard gate: a version tag only publishes if Release QA passed on this
       # exact commit. Keeps "QA before tagging" mechanical, not procedural.
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Checkout dac-starter (pinned ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: KhalilGibrotha/dac-starter
           ref: ${{ env.STARTER_REF }}
@@ -80,7 +80,7 @@ jobs:
             --engine-image "${IMAGE}:${GITHUB_SHA}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -90,7 +90,7 @@ jobs:
       # image identifies itself instead of inheriting the UBI base's labels.
       - name: Derive tags and OCI labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -103,12 +103,12 @@ jobs:
             org.opencontainers.image.licenses=MIT
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Build once into the local daemon so the scan gates publication rather
       # than trailing it. The push below reuses this layer cache.
       - name: Build for scanning
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: .devcontainer/Dockerfile.devspaces
@@ -151,7 +151,7 @@ jobs:
 
       - name: Push image
         id: push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: .devcontainer/Dockerfile.devspaces

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ jobs:
     name: Python tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -27,7 +27,7 @@ jobs:
     name: Shell lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Syntax-check every shell script
         run: |
           set -e

--- a/.github/workflows/pr-image-build.yml
+++ b/.github/workflows/pr-image-build.yml
@@ -25,9 +25,9 @@ jobs:
     name: Image builds (no push)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Checkout dac-starter (pinned ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: KhalilGibrotha/dac-starter
           ref: ${{ env.STARTER_REF }}
@@ -44,7 +44,7 @@ jobs:
             --starter-version "${STARTER_REF}" \
             --engine-image "pr-check-only"
       - name: Build the production image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: .devcontainer/Dockerfile.devspaces


### PR DESCRIPTION
## What

Supersedes dependabot #42, #41, #75, #39, #38.

| Action | Sites | Change |
|---|---|---|
| `actions/checkout` | 6 | v4 → v7 |
| `docker/build-push-action` | 3 | v5 / **v6** → v7 |
| `docker/login-action` | 1 | v3 → v4 |
| `docker/metadata-action` | 1 | v5 → v6 |
| `docker/setup-buildx-action` | 1 | v3 → v4 |

## Why batched

All five touch `docker-build.yml`. Merging any one makes the other four stale and needing a rebase, which is why they accumulated to eleven days old — each merge invalidated the rest.

Batching also normalises `build-push-action`, which was pinned at **v5 in `docker-build.yml` and v6 in `pr-image-build.yml`**.

## Breaking changes, checked rather than assumed

Each major bump carries a documented breaking change. All three were verified against this repo:

- **checkout v7** — changes `pull_request_target` defaults. No workflow here uses `pull_request_target`.
- **build-push-action v7** — removes `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. Neither appears anywhere in the repo.
- **setup-buildx-action v4** — deprecates the `install` input. It is called with no inputs at all.

Dependabot's #42 and #41 also passed CI individually, including a real image build.

## Scope

Version strings only: 12 insertions, 12 deletions across three files, all parsing.

## Note

`main` was red before this on a stale-layer-cache CVE (`openssh CVE-2026-60002`). #76's base-digest bump invalidated the layer and `dnf upgrade` picked up the errata — `main` is green again, so this builds on a healthy base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)