### PR TITLE
Vendor dac-starter v1.2.0 into the image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ env:
   # Pinned ref of the dac-starter repo vendored into the image for
   # dac-init/dac-update. Bump deliberately when starter changes merge —
   # this is the one human step in the stock-config release path.
-  STARTER_REF: v1.1.1
+  STARTER_REF: v1.2.0
 
 jobs:
   build-and-push:

--- a/.github/workflows/pr-image-build.yml
+++ b/.github/workflows/pr-image-build.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-image-build.yml"
 
 env:
-  STARTER_REF: v1.1.1
+  STARTER_REF: v1.2.0
 
 jobs:
   image-build:


### PR DESCRIPTION
Bumps `STARTER_REF` `v1.1.1` → `v1.2.0` in both build workflows — the one human step in the stock-config release path, and the last link in this release chain.

## What `dac-init` hands a new adopter after this builds

- **Secret scan (gitleaks)** as a fifth blocking gate
- **Job summaries on every gate** — files checked, findings counted, commits scanned
- **The `lint-prose.py` Vale report** — per-document findings table and a percent-error-free score, advisory on findings but failing when Vale itself cannot run
- **markdownlint in the pre-commit hooks**, which previously claimed CI parity without it
- **Dev Container parity** for local podman and docker
- **The documented commit-to-merge flow and existing-corpus adoption guide** — including the opt-in-per-file behavior that lets an existing repo migrate one document at a time

Full notes: [dac-starter v1.2.0](https://github.com/KhalilGibrotha/dac-starter/releases/tag/v1.2.0) — four PRs, 17 commits, 37 files.

## Pre-verified

`gen-stock-hashes.py --starter <v1.2.0 tree> --verify` run locally: **history OK, all 177 managed files covered.** That is the same gate the image build runs, so it should not be the surprise here.

The Release QA precondition applies only to tag builds (`if: github.ref_type == 'tag'`), so merging to `main` publishes without a QA dispatch. Release QA already passed green on the current `main` after toolkit #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)