### PR TITLE
Record the branch model this repo actually uses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,11 @@ image.
 1. **Public repo.** No organization identifiers anywhere — files, commit
    messages, PR and issue text. Org identity enters at build time in content
    repos via `--org`.
-2. **Branch flow `develop → main`.** The image builds only on push to `main`
+2. **Trunk-based on `main`.** Short-lived `feat/`, `fix/`, `chore/`, or
+   `docs/` branches open a PR against `main` and are deleted on merge. There
+   is no `develop` branch — the release gate is the `v*` tag plus a green
+   Release QA run, not an integration branch, so a second long-lived branch
+   only adds a place for work to go stale. The image builds on push to `main`
    (path-filtered) and on `v*` tags.
 
 ## Critical Fragile Areas
@@ -89,10 +93,10 @@ image.
 
 ## Release Process
 
-1. Merge `develop → main`. The docker-build workflow runs: starter vendor +
-   hash-history gate → Trivy gate (HIGH/CRITICAL, ignore-unfixed) → push
-   `:latest` + `:sha` → provenance attestation + CycloneDX SBOM + cosign
-   keyless signing.
+1. Merge the feature branch into `main`. The docker-build workflow runs:
+   starter vendor + hash-history gate → Trivy gate (HIGH/CRITICAL,
+   ignore-unfixed) → push `:latest` + `:sha` → provenance attestation +
+   CycloneDX SBOM + cosign keyless signing.
 2. Dispatch the **Release QA** workflow (runs inside the published image:
    tool presence, starter-tree integrity, dac-init contract, end-to-end
    render). Green is the precondition for tagging — the tag build verifies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Update devfile to use UDI base image
 ```
 
 Avoid:
+
 - `Fixed...`, `Fixes...`, `Adding...`
 - Vague messages like `updates` or `misc fixes`
 
@@ -59,6 +60,7 @@ Avoid:
 ## Reporting Bugs
 
 Open a GitHub issue with:
+
 - A description of the problem
 - Steps to reproduce
 - Expected vs actual behavior

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,23 +5,27 @@ dac-toolkit is a public, MIT-licensed documentation toolchain. Contributions are
 ## Branch Model
 
 ```text
-main        — stable, tagged releases only
-develop     — integration branch; all PRs target here
-feature/*   — short-lived feature branches from develop
-fix/*       — short-lived fix branches from develop
+main        — the trunk; PRs target here, and merging is what releases
+feat/*      — short-lived feature branches from main, deleted on merge
+fix/*       — short-lived fix branches
+chore/*     — dependency bumps, config, release plumbing
+docs/*      — documentation-only changes
 ```
 
-Do not push directly to `main`. All changes flow through `develop` via pull request.
+Do not push directly to `main`; every change arrives by pull request. There
+is no `develop` branch — the release gate is the `v*` tag plus a green
+Release QA run, so a second long-lived branch would only be somewhere for
+work to go stale.
 
-> **Note:** The `devfile.yaml` in this repo targets `revision: main` for workspace users who want a stable environment. As a contributor, clone the repo normally and branch from `develop` as described in Getting Started below.
+> **Note:** `devfile.yaml` targets `revision: main`, which is also the branch
+> you contribute against.
 
 ## Getting Started
 
 ```bash
 git clone https://github.com/KhalilGibrotha/dac-toolkit.git
 cd dac-toolkit
-git checkout develop
-git checkout -b feature/your-feature-name
+git checkout -b feat/your-feature-name
 ```
 
 ## Making Changes
@@ -47,7 +51,7 @@ Avoid:
 
 ## Pull Requests
 
-1. Target `develop`, not `main`.
+1. Target `main`.
 2. Include a short description of what changed and why.
 3. Link any related issues in the PR body.
 4. Automated review agents (Gemini, Copilot, Codex) will comment — address legitimate findings before merge.
@@ -66,7 +70,9 @@ Open an issue before starting significant work. This avoids duplicated effort an
 
 ## Release Process
 
-Releases are tagged on `main` from `develop` after sufficient stability. Tag format: `vMAJOR.MINOR.PATCH`. The Docker image tag aligns with the release tag.
+Releases are tagged on `main`. Tag format: `vMAJOR.MINOR.PATCH`. The Docker
+image tag aligns with the release tag, and a tag build only publishes if a
+Release QA run passed on that exact commit.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Documentation-only. Both files described a `develop`-plus-`main` model that this repo does not follow — every recent change merged straight to `main` by PR, and the stale branches have now been deleted (dac-toolkit: 11 removed, including `develop`; dac-starter: 3).

The reasoning is the part worth keeping: **the choice turns on whether "merged" and "published" are the same event.** Here they are — a merge to `main` is the release, gated by the `v*` tag and a green Release QA run — so a second long-lived branch is only somewhere for work to go stale. Where publication is a separate, slower step, which is common for documentation with a review cycle, `develop` earns its keep. The starter's CONTRIBUTING now presents both and tells an adopter how to pick, rather than recommending one model and following another.

Content repos consuming this engine keep their `develop → master` flow deliberately; the note says so, so the divergence does not get read as drift and "fixed" later.