### PR TITLE
Line endings: catch-all attributes and a gate against regression

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,27 @@ jobs:
           python -m pytest scripts/tests -q
           python -m pytest docx_builder/tests -q
 
+  line-endings:
+    name: Line endings
+    runs-on: ubuntu-latest
+    steps:
+      # The check reads `git ls-files --eol`, so it needs the index rather
+      # than the working tree. A checkout is enough; a bare file copy is not.
+      - uses: actions/checkout@v7
+      - name: Check tracked files for CRLF and misclassified text
+        run: python3 scripts/lint-line-endings.py --path .
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Line endings - ${{ job.status }}"
+            echo
+            echo "Tracked text files must reach the index as LF. CRLF renders a"
+            echo "four-line edit as a whole-file rewrite, and a text file git"
+            echo "has classified binary silently ignores its own .gitattributes"
+            echo "rule - which no pattern can fix, only this check can find."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   shell-lint:
     name: Shell lint
     runs-on: ubuntu-latest

--- a/scripts/lint-line-endings.py
+++ b/scripts/lint-line-endings.py
@@ -18,6 +18,15 @@ inert for the file, and the usual cause is a raw control byte embedded in
 the source - the kind of thing that is invisible in an editor and fatal in a
 container.
 
+Worth stating because it is counter-intuitive: no .gitattributes pattern
+rescues that case. `text` and `text=auto` behave identically once git's
+detector has called a file binary, because the attribute requests a
+conversion the detector never runs. Measured, not assumed - a .sh file
+holding a lone CR lands at `i/-text` under `* text=auto eol=lf` and under an
+explicit `*.sh text eol=lf` alike, while an ordinary CRLF file normalizes to
+`i/lf` under both. So a catch-all is not the weaker choice, and this check
+is the only thing that catches what neither pattern can.
+
 Usage:
     lint-line-endings.py [--path .]
 """
@@ -46,8 +55,16 @@ def main() -> int:
             ["git", "-C", args.path, "ls-files", "--eol"],
             capture_output=True, text=True, check=True,
         ).stdout
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        print(f"cannot read git index: {exc}", file=sys.stderr)
+    except FileNotFoundError:
+        print("cannot read git index: git is not on PATH", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        # git's own stderr says which of these it was - not a repository,
+        # bad --path, corrupt index. Printing only the exception object
+        # gives a CI reader an exit status and nothing to act on.
+        print(f"cannot read git index (git exited {exc.returncode}):", file=sys.stderr)
+        print((exc.stderr or "").rstrip() or "  (git wrote nothing to stderr)",
+              file=sys.stderr)
         return 2
 
     crlf: list[str] = []

--- a/scripts/lint-line-endings.py
+++ b/scripts/lint-line-endings.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Fail if any tracked text file carries CRLF in the git index.
+
+Why this exists as a gate rather than a convention: .gitattributes is the
+mechanism that keeps line endings consistent, but it is silent when it is
+wrong. A pattern that misses a file type produces no error - the file simply
+carries CRLF into the index, and the first symptom is a four-line edit
+rendering as a whole-file rewrite, weeks later, in someone's pull request.
+
+That happened here: eol=lf was pinned for *.sh, *.py, *.yml and *.yaml but
+never for *.md, and 220 of 289 tracked files accumulated CRLF before anyone
+noticed. This check turns that silence into a failing job.
+
+It also reports files git has classified as BINARY (`i/-text`) when their
+extension suggests otherwise. That classification makes .gitattributes
+inert for the file, and the usual cause is a raw control byte embedded in
+the source - the kind of thing that is invisible in an editor and fatal in a
+container.
+
+Usage:
+    lint-line-endings.py [--path .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+# Extensions that must never be classified binary. A binary classification
+# here means an embedded control byte, not a legitimately binary format.
+TEXT_EXTENSIONS = {
+    ".md", ".qmd", ".yml", ".yaml", ".py", ".sh", ".json", ".jsonc",
+    ".csv", ".txt", ".cfg", ".ini", ".conf", ".toml", ".scss", ".j2",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", default=".", help="Repository root (default: cwd).")
+    args = ap.parse_args()
+
+    try:
+        out = subprocess.run(
+            ["git", "-C", args.path, "ls-files", "--eol"],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"cannot read git index: {exc}", file=sys.stderr)
+        return 2
+
+    crlf: list[str] = []
+    mixed: list[str] = []
+    wrongly_binary: list[str] = []
+    checked = 0
+
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        index_attr = parts[0]          # e.g. i/lf, i/crlf, i/mixed, i/-text
+        path = line.split("\t")[-1].strip()
+        checked += 1
+
+        if index_attr == "i/crlf":
+            crlf.append(path)
+        elif index_attr == "i/mixed":
+            mixed.append(path)
+        elif index_attr == "i/-text":
+            dot = path.rfind(".")
+            if dot != -1 and path[dot:].lower() in TEXT_EXTENSIONS:
+                wrongly_binary.append(path)
+
+    for path in crlf:
+        print(f"CRLF     {path}")
+    for path in mixed:
+        print(f"MIXED    {path}")
+    for path in wrongly_binary:
+        print(f"BINARY?  {path}  (text extension classified binary)")
+
+    print()
+    print(f"Checked {checked} tracked file(s). "
+          f"{len(crlf)} CRLF, {len(mixed)} mixed, "
+          f"{len(wrongly_binary)} misclassified.")
+
+    if not (crlf or mixed or wrongly_binary):
+        print("PASS Line endings are consistent.")
+        return 0
+
+    print()
+    if crlf or mixed:
+        print("Fix: confirm .gitattributes covers these paths, then run")
+        print("     git add --renormalize . && git commit")
+    if wrongly_binary:
+        print("A text file classified binary usually holds a raw control byte.")
+        print("Remove the byte first - renormalizing will not touch the file")
+        print("while git still believes it is binary.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vale-bootstrap.sh
+++ b/scripts/vale-bootstrap.sh
@@ -30,7 +30,7 @@ fi
 # Resolve StylesPath from .vale.ini rather than assuming a layout. Copying to
 # the wrong path leaves BasedOnStyles unresolvable in an offline workspace,
 # which surfaces as a confusing "style not found" rather than a missing file.
-STYLES_REL="$(sed -n 's/^[[:space:]]*StylesPath[[:space:]]*=[[:space:]]*//p'     "$CONTENT_DIR/.vale.ini" | head -n 1 | tr -d '')"
+STYLES_REL="$(sed -n 's/^[[:space:]]*StylesPath[[:space:]]*=[[:space:]]*//p'     "$CONTENT_DIR/.vale.ini" | head -n 1 | tr -d '\r')"
 STYLES_REL="${STYLES_REL:-.vale/styles}"
 STYLES_DIR="$CONTENT_DIR/$STYLES_REL"
 


### PR DESCRIPTION
CRLF was entering the git index unchallenged, so a four-line edit could render as a whole-file rewrite. In `architecture-docs` that reached **220 of 289 files**, and four small SAD changes produced a **627-insertion / 626-deletion single-hunk diff** — unreviewable, which defeats keeping documents in git at all.

## Cause

`.gitattributes` pinned `eol=lf` for a *list of extensions*. That reads like coverage and isn't — anything not on the list falls through to `core.autocrlf`, which is `true` in every local clone here.

Replaced with `* text=auto eol=lf` plus an explicit binary list. A catch-all cannot be outgrown by a file type nobody anticipated, and it **overrides `core.autocrlf`**, so behaviour stops depending on how an individual machine is configured. That is the actual prevention; renormalization is just cleanup of what already accumulated.

## The gate

`.gitattributes` is silent when it is wrong. A missing pattern produces no error — the file just carries CRLF, and the symptom appears weeks later in someone's review. `scripts/lint-line-endings.py` turns that silence into a failing job, and also flags text files git has classified **binary**, since that classification makes `eol=lf` inert.

## It earned itself immediately

First run against dac-toolkit flagged `scripts/vale-bootstrap.sh`. It contained a **literal `0x0D` byte inside `tr -d '...'`** — a raw carriage return where the two-character escape belongs. bash and tr both handle it, so nothing ever complained. But a raw control byte makes git treat the file as binary, and a binary file's `eol=lf` attribute does nothing: the one script most needing LF endings was the single file exempt from the rule enforcing them.

Fixed with the escape sequence, which GNU tr interprets identically. Reclassified `i/-text` → `i/lf`.

## Verification

Renormalization proved mechanical rather than assumed — every staged file's committed bytes compared against its working-tree bytes with line endings collapsed. All identical except `.gitattributes` itself. All four repositories now report **0 CRLF, 0 mixed, 0 misclassified**.