### PR TITLE
Check every suffix in the eol gate, not just the last

### DIFF
--- a/scripts/lint-line-endings.py
+++ b/scripts/lint-line-endings.py
@@ -8,9 +8,10 @@ wrong. A pattern that misses a file type produces no error - the file simply
 carries CRLF into the index, and the first symptom is a four-line edit
 rendering as a whole-file rewrite, weeks later, in someone's pull request.
 
-That happened here: eol=lf was pinned for *.sh, *.py, *.yml and *.yaml but
-never for *.md, and 220 of 289 tracked files accumulated CRLF before anyone
-noticed. This check turns that silence into a failing job.
+That is not hypothetical. In one repository using this check, eol=lf was
+pinned for *.sh, *.py, *.yml and *.yaml but never for *.md, and 220 of 289
+tracked files accumulated CRLF before anyone noticed. This check turns that
+silence into a failing job.
 
 It also reports files git has classified as BINARY (`i/-text`) when their
 extension suggests otherwise. That classification makes .gitattributes
@@ -36,6 +37,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+from pathlib import PurePosixPath
 
 # Extensions that must never be classified binary. A binary classification
 # here means an embedded control byte, not a legitimately binary format.
@@ -43,6 +45,28 @@ TEXT_EXTENSIONS = {
     ".md", ".qmd", ".yml", ".yaml", ".py", ".sh", ".json", ".jsonc",
     ".csv", ".txt", ".cfg", ".ini", ".conf", ".toml", ".scss", ".j2",
 }
+
+# Extensionless files that are text by convention.
+TEXT_BASENAMES = {
+    ".gitignore", ".gitattributes", ".editorconfig", ".dockerignore",
+    ".yamllint", ".ansible-lint", "Containerfile", "Dockerfile",
+    "Makefile", "LICENSE", "CODEOWNERS",
+}
+
+
+def looks_like_text(path: str) -> bool:
+    """Should this path have been treated as text?
+
+    Checks EVERY suffix, not just the last one. A compound suffix is exactly
+    where the naive check fails: `example-caller.yml.disabled` yields
+    `.disabled`, which is in no list, so a disabled workflow carrying an
+    embedded control byte would pass a check whose entire job is to catch
+    that. Renaming a file is not supposed to remove it from the policy.
+    """
+    p = PurePosixPath(path)
+    if p.name in TEXT_BASENAMES:
+        return True
+    return any(s.lower() in TEXT_EXTENSIONS for s in p.suffixes)
 
 
 def main() -> int:
@@ -85,8 +109,7 @@ def main() -> int:
         elif index_attr == "i/mixed":
             mixed.append(path)
         elif index_attr == "i/-text":
-            dot = path.rfind(".")
-            if dot != -1 and path[dot:].lower() in TEXT_EXTENSIONS:
+            if looks_like_text(path):
                 wrongly_binary.append(path)
 
     for path in crlf:

--- a/scripts/lint-line-endings.py
+++ b/scripts/lint-line-endings.py
@@ -68,21 +68,29 @@ TEXT_BASENAMES = {
 def looks_like_text(path: str) -> bool:
     """Should this path have been treated as text?
 
-    The final suffix decides when it is a known binary format; inner
-    suffixes only rescue files whose final suffix is UNKNOWN. That covers
-    the rename case this exists for - `example-caller.yml.disabled` yields
-    `.disabled`, which names nothing, so `.yml` inside it counts and the
-    file stays under the policy. It does not cover `data.csv.gz`, where
-    `.gz` names a real binary format and the `.csv` inside it is content
-    the archive wraps, not the file's own encoding.
+    Scan suffixes right to left and let the first KNOWN one decide. The
+    suffix nearest the end that names a real format is the file's format;
+    anything after it is renaming (`.disabled`, `.bak`), and anything
+    before it is wrapped content.
+
+      example.yml.disabled   .disabled unknown -> .yml text     -> True
+      data.csv.gz            .gz binary                          -> False
+      data.csv.gz.disabled   .disabled unknown -> .gz binary     -> False
+      notes.md.bak           .bak unknown -> .md text            -> True
+
+    The last case above is why the scan cannot stop at the final suffix,
+    and the third is why it cannot match any suffix: both simpler rules
+    were tried, and each one misclassified a case the other got right.
     """
     p = PurePosixPath(path)
     if p.name in TEXT_BASENAMES:
         return True
-    suffixes = [s.lower() for s in p.suffixes]
-    if suffixes and suffixes[-1] in BINARY_EXTENSIONS:
-        return False
-    return any(s in TEXT_EXTENSIONS for s in suffixes)
+    for s in reversed([s.lower() for s in p.suffixes]):
+        if s in BINARY_EXTENSIONS:
+            return False
+        if s in TEXT_EXTENSIONS:
+            return True
+    return False
 
 
 def main() -> int:

--- a/scripts/lint-line-endings.py
+++ b/scripts/lint-line-endings.py
@@ -46,6 +46,17 @@ TEXT_EXTENSIONS = {
     ".csv", ".txt", ".cfg", ".ini", ".conf", ".toml", ".scss", ".j2",
 }
 
+# Formats that are binary no matter what the inner suffixes claim. The
+# FINAL suffix names the actual on-disk format: `data.csv.gz` carries `.csv`
+# in its suffixes, but a gzip is binary whatever it wraps.
+BINARY_EXTENSIONS = {
+    ".gz", ".bz2", ".xz", ".zst", ".zip", ".tar", ".tgz", ".7z",
+    ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp", ".svgz",
+    ".pdf", ".docx", ".pptx", ".xlsx",
+    ".woff", ".woff2", ".ttf", ".otf", ".eot",
+    ".so", ".dll", ".exe", ".bin", ".pyc", ".whl",
+}
+
 # Extensionless files that are text by convention.
 TEXT_BASENAMES = {
     ".gitignore", ".gitattributes", ".editorconfig", ".dockerignore",
@@ -57,16 +68,21 @@ TEXT_BASENAMES = {
 def looks_like_text(path: str) -> bool:
     """Should this path have been treated as text?
 
-    Checks EVERY suffix, not just the last one. A compound suffix is exactly
-    where the naive check fails: `example-caller.yml.disabled` yields
-    `.disabled`, which is in no list, so a disabled workflow carrying an
-    embedded control byte would pass a check whose entire job is to catch
-    that. Renaming a file is not supposed to remove it from the policy.
+    The final suffix decides when it is a known binary format; inner
+    suffixes only rescue files whose final suffix is UNKNOWN. That covers
+    the rename case this exists for - `example-caller.yml.disabled` yields
+    `.disabled`, which names nothing, so `.yml` inside it counts and the
+    file stays under the policy. It does not cover `data.csv.gz`, where
+    `.gz` names a real binary format and the `.csv` inside it is content
+    the archive wraps, not the file's own encoding.
     """
     p = PurePosixPath(path)
     if p.name in TEXT_BASENAMES:
         return True
-    return any(s.lower() in TEXT_EXTENSIONS for s in p.suffixes)
+    suffixes = [s.lower() for s in p.suffixes]
+    if suffixes and suffixes[-1] in BINARY_EXTENSIONS:
+        return False
+    return any(s in TEXT_EXTENSIONS for s in suffixes)
 
 
 def main() -> int:

--- a/scripts/tests/test_lint_line_endings.py
+++ b/scripts/tests/test_lint_line_endings.py
@@ -1,0 +1,142 @@
+"""
+tests/test_lint_line_endings.py — Tests for the eol gate's text/binary
+classification and its end-to-end behaviour against a real git index.
+
+The classification has been wrong twice, in opposite directions: first it
+read only the final suffix, so a renamed `*.yml.disabled` workflow silently
+left the policy; then the fix matched ANY suffix, so `data.csv.gz` — a
+genuinely binary gzip — was flagged as misclassified text. Both cases live
+here so neither regression comes back.
+
+Run with: python -m pytest scripts/tests/ from the repo root.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "lint-line-endings.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("lint_line_endings", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load()
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # Plain text extensions.
+        ("scripts/foo.sh", True),
+        ("docs/a.md", True),
+        # Compound suffix whose FINAL part names nothing: the rename case.
+        # This is the file the check originally exempted by reading only
+        # the last suffix.
+        (".github/workflows/example-caller.yml.disabled", True),
+        ("notes.md.bak", True),
+        # Jinja templates: .j2 is itself a text extension.
+        ("roles/x/templates/config.yml.j2", True),
+        # Extensionless text, known by basename.
+        (".gitignore", True),
+        (".gitattributes", True),
+        ("Containerfile", True),
+        ("Makefile", True),
+        # Plain binary.
+        ("img/logo.png", False),
+        # No extension, unknown basename: cannot claim it is text.
+        ("bin/tool", False),
+        # Compound suffix whose FINAL part is a real binary format. The
+        # inner .csv/.md describe wrapped content, not the file's encoding.
+        ("data.csv.gz", False),
+        ("archive.tar.gz", False),
+        ("README.md.png", False),
+        # Case-insensitivity.
+        ("REPORT.MD", True),
+        ("PHOTO.PNG", False),
+    ],
+)
+def test_looks_like_text(path, expected):
+    assert MOD.looks_like_text(path) is expected
+
+
+def _run_gate(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--path", str(repo)],
+        capture_output=True, text=True,
+    )
+
+
+@pytest.fixture()
+def scratch_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    for k, v in (("user.email", "t@t"), ("user.name", "t")):
+        subprocess.run(["git", "-C", str(tmp_path), "config", k, v], check=True)
+    (tmp_path / ".gitattributes").write_text("* text=auto eol=lf\n")
+    (tmp_path / "good.sh").write_text("#!/bin/bash\necho ok\n", newline="\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-qm", "base"], check=True
+    )
+    return tmp_path
+
+
+def test_clean_tree_passes(scratch_repo: Path):
+    result = _run_gate(scratch_repo)
+    assert result.returncode == 0
+    assert "PASS" in result.stdout
+
+
+def test_committed_crlf_fails(scratch_repo: Path):
+    # hash-object applies the eol filter unless told otherwise, which would
+    # normalize the CRLF away and make this test prove nothing.
+    bad = scratch_repo / "bad.sh"
+    bad.write_bytes(b"#!/bin/bash\r\necho hi\r\n")
+    blob = subprocess.run(
+        ["git", "-C", str(scratch_repo), "hash-object", "-w",
+         "--no-filters", "bad.sh"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(scratch_repo), "update-index", "--add",
+         "--cacheinfo", f"100644,{blob},bad.sh"],
+        check=True,
+    )
+    result = _run_gate(scratch_repo)
+    assert result.returncode == 1
+    assert "CRLF" in result.stdout
+
+
+def test_text_file_classified_binary_fails(scratch_repo: Path):
+    # A lone CR inside the content makes git classify the file binary, at
+    # which point every eol attribute is inert. The gate is the only thing
+    # that catches this, which is the reason the gate exists.
+    cr = scratch_repo / "cr.sh"
+    cr.write_bytes(b'#!/bin/bash\necho "x" | tr -d \'\r\'\n')
+    subprocess.run(["git", "-C", str(scratch_repo), "add", "cr.sh"], check=True)
+    result = _run_gate(scratch_repo)
+    assert result.returncode == 1
+    assert "BINARY?" in result.stdout
+
+
+def test_binary_wrapper_not_flagged(scratch_repo: Path):
+    # A real gzip is i/-text and must NOT be reported: .gz names the format,
+    # whatever the inner suffix claims.
+    import gzip
+
+    gz = scratch_repo / "data.csv.gz"
+    gz.write_bytes(gzip.compress(b"a,b,c\n1,2,3\n"))
+    subprocess.run(
+        ["git", "-C", str(scratch_repo), "add", "data.csv.gz"], check=True
+    )
+    result = _run_gate(scratch_repo)
+    assert result.returncode == 0, result.stdout
+    assert "BINARY?" not in result.stdout

--- a/scripts/tests/test_lint_line_endings.py
+++ b/scripts/tests/test_lint_line_endings.py
@@ -59,6 +59,12 @@ MOD = _load()
         ("data.csv.gz", False),
         ("archive.tar.gz", False),
         ("README.md.png", False),
+        # A RENAMED binary: the final suffix names nothing, but the nearest
+        # known suffix is binary. Right-to-left scanning is what gets this
+        # right - final-suffix-only and any-suffix rules each fail one of
+        # this row and the .yml.disabled row above.
+        ("data.csv.gz.disabled", False),
+        ("backup.tar.gz.old", False),
         # Case-insensitivity.
         ("REPORT.MD", True),
         ("PHOTO.PNG", False),


### PR DESCRIPTION
Backports a fix found during review of the ansible-dev-workspace copy of this script (KhalilGibrotha/ansible-dev-workspace#10).

The binary-misclassification check used `path.rfind(".")` — final suffix only. A compound-suffix file like `example-caller.yml.disabled` resolves to `.disabled`, matches nothing, and is skipped by the check whose entire job is catching embedded control bytes in text files. Renaming a covered file silently removed it from the policy.

Now checks every suffix via `PurePosixPath.suffixes`, plus a `TEXT_BASENAMES` set for extensionless text files (`.gitignore`, `Containerfile`, `Makefile`, `LICENSE`…), which have no suffix to inspect at all.

Unit cases (all pass): compound text suffixes flagged, `.gitignore`/`Containerfile` flagged by basename, `archive.tar.gz` correctly excluded — a genuinely binary format with a compound suffix must not regress.

This is the canonical copy: the image bakes `scripts/` in, so dac-starter's containerized gate picks this up on the next image build with no change there.