### PR TITLE
Derive revision-table authorship from git

### DIFF
--- a/docx_builder/src/docx_builder/builder.py
+++ b/docx_builder/src/docx_builder/builder.py
@@ -111,7 +111,7 @@ def build_document(
     rev_section.header.is_linked_to_previous = False
     remove_page_border(rev_section)
 
-    build_revision_table(doc, meta)
+    build_revision_table(doc, meta, md_path=md_path)
 
     # ── 6. Section 4: Body content ────────────────────────────────────────────
     body_section = add_section_break(doc, WD_SECTION.NEW_PAGE)

--- a/docx_builder/src/docx_builder/git_metadata.py
+++ b/docx_builder/src/docx_builder/git_metadata.py
@@ -148,8 +148,13 @@ def commit_history(md_path: str, limit: int = REVISION_LIMIT,
     # %x1f is a unit separator: commit subjects contain almost anything, and
     # splitting on a character a human can type is how a subject with a pipe
     # or a tab corrupts the parse.
+    # --follow traverses renames. Without it a moved or renamed document
+    # shows only the commits made under its CURRENT path, so the table
+    # attributes it to whoever renamed it and drops the original authors -
+    # the same class of error as crediting a line-ending pass. It requires
+    # exactly one pathspec, which is what is passed here.
     out = _git(
-        ["log", f"-{max(1, limit)}", "--date=short",
+        ["log", "--follow", f"-{max(1, limit)}", "--date=short",
          "--format=%ad%x1f%ae%x1f%an%x1f%s", "--", path.name],
         path.parent,
     )

--- a/docx_builder/src/docx_builder/git_metadata.py
+++ b/docx_builder/src/docx_builder/git_metadata.py
@@ -1,0 +1,248 @@
+"""
+git_metadata.py — Derive document authorship from git rather than front matter.
+
+A hand-maintained `author:` field is wrong the moment somebody else edits the
+document, and nothing detects it. Git already records who changed what and
+when, so the revision table can read the fact instead of a copy of it.
+
+Two modes:
+
+  * Default. A document with no `revision_history:` gets one auto-generated
+    row, and the author and date on that row come from the file's most recent
+    commit. Front matter supplies the fallback when git cannot answer.
+
+  * `revision_history: auto`. Rows are generated from the file's commit
+    history, newest first, capped by REVISION_LIMIT. Use this where the
+    document genuinely wants a changelog.
+
+An explicit `revision_history:` list still wins over both. Curating the
+history by hand stays available; it is just no longer the only option.
+
+Display names come from the commit email, because a corporate address encodes
+the name: `first.last@example.org` yields `First Last`. Addresses that carry
+no name (noreply forms, bare handles) fall back to the git author name, then
+to front matter. An `authors:` map in org.yaml overrides any of it for
+identities the pattern cannot reach.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+# How many commits `revision_history: auto` renders. A document with 200
+# commits does not want a 200-row table before its first heading.
+REVISION_LIMIT = 10
+
+# Addresses that identify an account rather than a person. Matching one means
+# the email cannot supply a display name.
+_OPAQUE_EMAIL = re.compile(
+    r"(noreply|no-reply|users\.noreply\.github\.com|\[bot\]|actions@github)",
+    re.IGNORECASE,
+)
+
+# first.last@domain or first.middle.last@domain — the corporate form.
+_DOTTED_LOCAL = re.compile(r"^([A-Za-z]+(?:[.\-_][A-Za-z]+)+)@")
+
+
+def display_name_from_email(email: str) -> str | None:
+    """Turn a corporate address into a display name, or None if it cannot.
+
+    `alex.gambino@ncsecu.org` -> `Alex Gambino`.
+
+    Returns None rather than guessing when the local part carries no
+    separator, because `agambino@example.org` has no recoverable split point
+    and inventing one produces a name that is confidently wrong.
+    """
+    if not email or _OPAQUE_EMAIL.search(email):
+        return None
+    m = _DOTTED_LOCAL.match(email.strip())
+    if not m:
+        return None
+    parts = re.split(r"[.\-_]", m.group(1))
+    return " ".join(p.capitalize() for p in parts if p)
+
+
+def _git(args: list[str], cwd: Path) -> str | None:
+    """Run git, returning stdout, or None if git cannot answer.
+
+    Every failure mode is the same answer here: no history available, use the
+    fallback. A document must still render outside a checkout - in a release
+    tarball, or a container that mounted only the sources.
+    """
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _resolve_name(email: str, git_name: str, overrides: dict) -> str:
+    """Best available display name for one commit identity.
+
+    Overrides are checked against both the email and the git author name, so
+    a historical identity can be mapped by whichever of the two is stable.
+    Commits predating a corporate git config carry neither a usable address
+    nor a real name, and the override map is the only way to reach them.
+    """
+    if email and email.lower() in overrides:
+        return overrides[email.lower()]
+    if git_name and git_name.lower() in overrides:
+        return overrides[git_name.lower()]
+    from_email = display_name_from_email(email)
+    if from_email:
+        return from_email
+    return git_name or ""
+
+
+def contributors(md_path: str, author_overrides: dict | None = None,
+                 max_named: int = 2) -> str:
+    """Who wrote this document, most prolific first.
+
+    The author column names contributors rather than the last committer.
+    Attributing a document to whoever touched it last means a typo fix - or a
+    repo-wide line-ending normalization - silently reassigns authorship, which
+    is exactly the inaccuracy this is meant to remove.
+
+    Caps at max_named because the column is 1.5 inches wide; beyond that it
+    reports the overflow rather than wrapping to five lines.
+    """
+    history = commit_history(md_path, limit=200, author_overrides=author_overrides)
+    if not history:
+        return ""
+    counts: dict[str, int] = {}
+    for row in history:
+        name = row["author"]
+        if name:
+            counts[name] = counts.get(name, 0) + 1
+    if not counts:
+        return ""
+    ranked = sorted(counts, key=lambda n: (-counts[n], n))
+    if len(ranked) <= max_named:
+        return ", ".join(ranked)
+    return f"{', '.join(ranked[:max_named])} +{len(ranked) - max_named}"
+
+
+def commit_history(md_path: str, limit: int = REVISION_LIMIT,
+                   author_overrides: dict | None = None) -> list[dict]:
+    """Commits that touched this file, newest first.
+
+    Each entry: {date, author, subject}. Empty list when git cannot answer,
+    which callers treat as "fall back to front matter" rather than as an
+    error.
+    """
+    path = Path(md_path).resolve()
+    if not path.exists():
+        return []
+    overrides = {k.lower(): v for k, v in (author_overrides or {}).items()}
+
+    # %x1f is a unit separator: commit subjects contain almost anything, and
+    # splitting on a character a human can type is how a subject with a pipe
+    # or a tab corrupts the parse.
+    out = _git(
+        ["log", f"-{max(1, limit)}", "--date=short",
+         "--format=%ad%x1f%ae%x1f%an%x1f%s", "--", path.name],
+        path.parent,
+    )
+    if not out:
+        return []
+
+    rows = []
+    for line in out.splitlines():
+        fields = line.split("\x1f")
+        if len(fields) != 4:
+            continue
+        date, email, git_name, subject = fields
+        rows.append({
+            "date": date,
+            "author": _resolve_name(email, git_name, overrides),
+            "subject": subject,
+        })
+    return rows
+
+
+def revision_rows(md_path: str, meta: dict) -> list[dict] | None:
+    """Rows for the revision table, or None to use the caller's own default.
+
+    Resolution order, most explicit first:
+
+      1. `revision_history:` as a list — the author curated it, leave it alone
+      2. `revision_history: auto` — generate a changelog from git
+      3. no revision_history — one row, with author and date taken from the
+         last commit and everything else from front matter
+    """
+    declared = meta.get("revision_history")
+    overrides = (meta.get("org") or {}).get("authors") or meta.get("authors") or {}
+
+    if isinstance(declared, list) and declared:
+        # Curated by hand, and it stays that way: a row reading "Records the
+        # 2026-07-27 engineering decision" is editorial content no commit
+        # subject reproduces. The one thing git adds is filling a row whose
+        # author was left BLANK, so a curator can write version, date and
+        # description and let authorship resolve itself.
+        if all(str(r.get("author", "")).strip() for r in declared):
+            return None
+        names = contributors(md_path, author_overrides=overrides)
+        if not names:
+            return None
+        return [
+            {**row, "author": row.get("author") or names}
+            for row in declared
+        ]
+
+    history = commit_history(md_path, author_overrides=overrides)
+
+    if isinstance(declared, str) and declared.strip().lower() == "auto":
+        if not history:
+            return None
+        return [
+            {
+                "version": "",
+                "date": row["date"],
+                "author": row["author"],
+                "description": row["subject"],
+            }
+            for row in history
+        ]
+
+    # Default: one row, with only the author taken from git.
+    #
+    # The DATE deliberately stays with front matter. `date:` means the last
+    # SUBSTANTIVE revision - a human judgement - while git's newest commit
+    # includes typo fixes and repo-wide reformatting. A line-ending
+    # normalization pass should not advance a document's revision date.
+    if not history:
+        return None
+    names = contributors(md_path, author_overrides=overrides)
+    if not names:
+        return None
+    status = str(meta.get("status", "")).lower()
+    return [{
+        "version": meta.get("version", "1.0"),
+        "date": str(meta.get("date", "")),
+        "author": names,
+        "description": "Initial draft" if status == "draft" else "Initial release",
+    }]
+
+
+def resolve_owner(meta: dict) -> str:
+    """Document owner: front matter first, then the org default.
+
+    Owner names a team rather than a person, so it belongs in org.yaml where
+    one edit sets it for every document. A document that genuinely differs -
+    one owned by another team - overrides it in its own front matter.
+    """
+    own = meta.get("owner")
+    if own:
+        return str(own)
+    org = meta.get("org") or {}
+    return str(org.get("owner", "") or "")

--- a/docx_builder/src/docx_builder/revision_history.py
+++ b/docx_builder/src/docx_builder/revision_history.py
@@ -20,15 +20,18 @@ from .xml_helpers import (
     set_run_color, para_spacing,
     set_cell_bg, set_cell_borders, set_table_border,
 )
+from .git_metadata import revision_rows, resolve_owner
 
 
-def build_revision_table(doc, meta: dict):
+def build_revision_table(doc, meta: dict, md_path: str | None = None):
     """
     Add a revision history table to the document.
 
     Args:
-        doc:  python-docx Document
-        meta: parsed YAML front matter dictionary
+        doc:     python-docx Document
+        meta:    parsed YAML front matter dictionary
+        md_path: source Markdown path, used to read authorship from git.
+                 Optional so the builder still works outside a checkout.
 
     Table columns: Version | Date | Author | Description
     Column widths sum to 8.0 inches (matches 1-inch margins on 8.5" page).
@@ -70,14 +73,27 @@ def build_revision_table(doc, meta: dict):
         set_run_color(run, RGBColor(0xFF, 0xFF, 0xFF))
 
     # ── Revision rows ─────────────────────────────────────────────────────────
-    revisions = meta.get('revision_history', [])
+    #
+    # Git is consulted first. A hand-maintained author field is wrong the
+    # moment somebody else edits the document, and nothing detects it; git
+    # already records who changed what and when. revision_rows returns None
+    # whenever the front matter should win instead - an explicitly curated
+    # list, or no git history to read.
+    revisions = None
+    if md_path:
+        revisions = revision_rows(md_path, meta)
+
+    if revisions is None:
+        declared = meta.get('revision_history', [])
+        revisions = declared if isinstance(declared, list) else []
+
     if not revisions:
-        # Auto-generate from top-level metadata fields when no explicit list
+        # Nothing curated and nothing derivable: fall back to front matter.
         revisions = [{
             'version':     meta.get('version', '1.0'),
             'date':        str(meta.get('date', '')),
             'author':      meta.get('author', ''),
-            'description': 'Initial draft' if meta.get('status', '').lower() == 'draft'
+            'description': 'Initial draft' if str(meta.get('status', '')).lower() == 'draft'
                            else 'Initial release',
         }]
 
@@ -107,7 +123,7 @@ def build_revision_table(doc, meta: dict):
     related_docs = meta.get('related_docs', [])
 
     meta_fields = [
-        ("Document Owner", meta.get('owner', '')),
+        ("Document Owner", resolve_owner(meta)),
         ("Audience",       ', '.join(audience)     if isinstance(audience, list)     else str(audience)),
         ("Related Docs",   ', '.join(related_docs) if isinstance(related_docs, list) else str(related_docs)),
     ]

--- a/docx_builder/tests/test_git_metadata.py
+++ b/docx_builder/tests/test_git_metadata.py
@@ -121,6 +121,26 @@ def test_contributors_overflow_is_reported_not_wrapped(repo):
     assert contributors(str(doc), max_named=2).endswith("+2")
 
 
+def test_authorship_survives_a_rename(tmp_path):
+    """A rename must not reassign the document to whoever moved it.
+
+    `git log -- <path>` sees only commits made under the CURRENT name, so
+    without --follow a renamed document is credited entirely to the rename
+    commit. Same class of error as crediting a line-ending pass.
+    """
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    old = tmp_path / "old.md"
+    _commit(tmp_path, "Original Author", "original.author@ncsecu.org",
+            "write the document", old, "# doc\n\nbody\n")
+    subprocess.run(["git", "-C", str(tmp_path), "mv", "old.md", "new.md"],
+                   check=True, capture_output=True)
+    _commit(tmp_path, "Renamer Person", "renamer.person@ncsecu.org",
+            "rename file", tmp_path / "new.md", "# doc\n\nbody\n")
+
+    names = contributors(str(tmp_path / "new.md"), max_named=5)
+    assert "Original Author" in names, "pre-rename authorship was lost"
+
+
 def test_author_name_override_reaches_historical_identities(repo):
     doc = repo / "doc.md"
     _commit(repo, "oldhandle", "oldhandle@users.noreply.github.com",

--- a/docx_builder/tests/test_git_metadata.py
+++ b/docx_builder/tests/test_git_metadata.py
@@ -1,0 +1,185 @@
+"""
+tests/test_git_metadata.py — Authorship derived from git rather than front matter.
+
+The revision table used to print whatever `author:` said, which is wrong the
+moment somebody else edits the document and nothing detects it. These tests
+pin the three behaviours that make the derived version trustworthy:
+
+  * a display name is derived only when the address actually encodes one,
+  * authorship reflects who wrote the document rather than who touched it
+    last, so a typo fix cannot reassign it,
+  * every failure mode falls back rather than raising, because a document
+    must still render outside a git checkout.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from docx_builder.git_metadata import (
+    commit_history,
+    contributors,
+    display_name_from_email,
+    resolve_owner,
+    revision_rows,
+)
+
+
+# ── display_name_from_email ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("email", "expected"),
+    [
+        ("alex.gambino@ncsecu.org", "Alex Gambino"),
+        ("ALEX.GAMBINO@NCSECU.ORG", "Alex Gambino"),
+        ("jane.q.public@example.org", "Jane Q Public"),
+        ("mary-jane.watson@example.org", "Mary Jane Watson"),
+        # No separator in the local part: there is no recoverable split point,
+        # and inventing one produces a name that is confidently wrong.
+        ("agambino@example.org", None),
+        # Account identities, not people.
+        ("khalilgibrotha@users.noreply.github.com", None),
+        ("49699333+dependabot[bot]@users.noreply.github.com", None),
+        ("actions@github.com", None),
+        ("", None),
+    ],
+)
+def test_display_name_from_email(email, expected):
+    assert display_name_from_email(email) == expected
+
+
+# ── graceful degradation ─────────────────────────────────────────────────────
+
+def test_missing_file_returns_empty(tmp_path):
+    assert commit_history(str(tmp_path / "nope.md")) == []
+
+
+def test_outside_a_git_checkout_returns_empty(tmp_path):
+    # A release tarball or a container mounting only sources: no .git, and the
+    # document must still render.
+    doc = tmp_path / "doc.md"
+    doc.write_text("# hi\n")
+    assert commit_history(str(doc)) == []
+    assert revision_rows(str(doc), {"version": "1.0"}) is None
+
+
+# ── against a real repository ────────────────────────────────────────────────
+
+def _commit(repo: Path, name: str, email: str, message: str, path: Path, text: str):
+    path.write_text(text)
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True,
+                   capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", message],
+        check=True, capture_output=True,
+        env={
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "GIT_AUTHOR_NAME": name, "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name, "GIT_COMMITTER_EMAIL": email,
+        },
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    doc = tmp_path / "doc.md"
+    # Two commits from one author, one from another. The MINORITY author
+    # commits last, which is the case that catches last-committer logic.
+    _commit(tmp_path, "Alex Gambino", "alex.gambino@ncsecu.org",
+            "initial draft", doc, "# doc\n\nfirst\n")
+    _commit(tmp_path, "Alex Gambino", "alex.gambino@ncsecu.org",
+            "expand section", doc, "# doc\n\nfirst\nsecond\n")
+    _commit(tmp_path, "Dana Scully", "dana.scully@ncsecu.org",
+            "fix typo", doc, "# doc\n\nfirst\nsecond fixed\n")
+    return tmp_path
+
+
+def test_commit_history_is_newest_first(repo):
+    rows = commit_history(str(repo / "doc.md"))
+    assert [r["subject"] for r in rows] == [
+        "fix typo", "expand section", "initial draft",
+    ]
+    assert rows[0]["author"] == "Dana Scully"
+
+
+def test_contributors_ranked_by_volume_not_recency(repo):
+    # Dana committed most recently; Alex wrote most of it. A typo fix must not
+    # reassign authorship of the document.
+    assert contributors(str(repo / "doc.md")) == "Alex Gambino, Dana Scully"
+
+
+def test_contributors_overflow_is_reported_not_wrapped(repo):
+    doc = repo / "doc.md"
+    for who in ("Fox Mulder", "Walter Skinner"):
+        first, last = who.lower().split()
+        _commit(repo, who, f"{first}.{last}@ncsecu.org", f"edit by {who}",
+                doc, f"# doc\n\n{who} was here\n")
+    # 1.5-inch column: name two, count the rest.
+    assert contributors(str(doc), max_named=2).endswith("+2")
+
+
+def test_author_name_override_reaches_historical_identities(repo):
+    doc = repo / "doc.md"
+    _commit(repo, "oldhandle", "oldhandle@users.noreply.github.com",
+            "legacy commit", doc, "# doc\n\nlegacy\n")
+    # Without a mapping the handle is all that is available.
+    assert "oldhandle" in contributors(str(doc), max_named=5)
+    # Mapping by git author name reaches it.
+    mapped = contributors(str(doc), author_overrides={"oldhandle": "Alex Gambino"},
+                          max_named=5)
+    assert "oldhandle" not in mapped
+    assert "Alex Gambino" in mapped
+
+
+# ── revision_rows resolution order ───────────────────────────────────────────
+
+def test_curated_list_wins(repo):
+    meta = {"revision_history": [{"version": "0.1", "author": "Someone"}]}
+    assert revision_rows(str(repo / "doc.md"), meta) is None
+
+
+def test_default_row_keeps_front_matter_date(repo):
+    # `date:` means last SUBSTANTIVE revision - a human judgement. Git's newest
+    # commit includes typo fixes and repo-wide reformatting, so a line-ending
+    # normalization pass must not advance a document's revision date.
+    meta = {"version": "0.3", "status": "Draft", "date": "2026-01-15",
+            "author": "Stale Value"}
+    rows = revision_rows(str(repo / "doc.md"), meta)
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-01-15"
+    assert rows[0]["version"] == "0.3"
+    assert rows[0]["author"] == "Alex Gambino, Dana Scully"
+    assert rows[0]["description"] == "Initial draft"
+
+
+def test_auto_mode_renders_a_changelog(repo):
+    meta = {"revision_history": "auto", "version": "0.3"}
+    rows = revision_rows(str(repo / "doc.md"), meta)
+    assert len(rows) == 3
+    # Here the per-row date IS the commit date, because each row is a commit.
+    assert rows[0]["description"] == "fix typo"
+    assert rows[0]["author"] == "Dana Scully"
+
+
+def test_auto_mode_without_history_falls_back(tmp_path):
+    doc = tmp_path / "doc.md"
+    doc.write_text("# hi\n")
+    assert revision_rows(str(doc), {"revision_history": "auto"}) is None
+
+
+# ── owner resolution ─────────────────────────────────────────────────────────
+
+def test_owner_prefers_front_matter():
+    meta = {"owner": "Network Engineering", "org": {"owner": "Infra Arch"}}
+    assert resolve_owner(meta) == "Network Engineering"
+
+
+def test_owner_falls_back_to_org_default():
+    assert resolve_owner({"org": {"owner": "Infra Arch"}}) == "Infra Arch"
+
+
+def test_owner_empty_when_neither_set():
+    assert resolve_owner({}) == ""

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -58,6 +58,13 @@ INFORMATIONAL_TYPES = {"meeting-notes"}
 # Informational documents (meeting notes, informal captures) have a reduced
 # required field set — no doc_type, domain, version, or owner.
 REQUIRED_FIELDS_STANDARD     = ["title", "doc_type", "domain", "department", "status", "version", "date", "author", "owner"]
+
+# Fields a repository-level org file may supply, so a document that omits
+# them still renders. Passing --org tells this linter which of these have a
+# default and drops them from the required set; without it, nothing changes.
+# Rendering and linting must agree on what a document is allowed to omit, or
+# CI rejects documents the builder handles perfectly well.
+ORG_DEFAULTABLE_FIELDS = ["owner"]
 REQUIRED_FIELDS_INFORMATIONAL = ["title", "status", "date", "author"]
 
 # Files to skip entirely (no front matter expected)
@@ -112,7 +119,29 @@ def valid_statuses_for(doc_type: str) -> set[str]:
     return STANDARD_STATUSES
 
 
-def validate(fm: dict) -> list[tuple[str, str]]:
+def _org_defaults(org_path: str | None) -> set[str]:
+    """Fields the org file supplies a default for.
+
+    Read leniently: a malformed or unreadable org file means "no defaults",
+    not a crash. Its own validity is not this linter's business.
+    """
+    if not org_path:
+        return set()
+    try:
+        with open(org_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return set()
+    org = data.get("org", data)
+    if not isinstance(org, dict):
+        return set()
+    return {
+        field for field in ORG_DEFAULTABLE_FIELDS
+        if str(org.get(field, "")).strip()
+    }
+
+
+def validate(fm: dict, org_defaults: set[str] | None = None) -> list[tuple[str, str]]:
     """
     Return a list of (severity, message) tuples.
     Severity is "ERROR" or "WARNING".
@@ -126,6 +155,9 @@ def validate(fm: dict) -> list[tuple[str, str]]:
         if status == "Informational"
         else REQUIRED_FIELDS_STANDARD
     )
+    # A field the org file defaults is not missing when a document omits it.
+    if org_defaults:
+        required = [f for f in required if f not in org_defaults]
 
     # Required fields
     for field in required:
@@ -160,7 +192,7 @@ def validate(fm: dict) -> list[tuple[str, str]]:
 
 # ── Scanner ────────────────────────────────────────────────────────────────────
 
-def scan(root: Path, strict: bool) -> int:
+def scan(root: Path, strict: bool, org_defaults: set[str] | None = None) -> int:
     """Walk root, validate each eligible .md file. Returns exit code."""
     errors   = 0
     warnings = 0
@@ -195,7 +227,7 @@ def scan(root: Path, strict: bool) -> int:
                 skipped += 1
                 continue
 
-            issues = validate(fm)
+            issues = validate(fm, org_defaults)
             checked += 1
 
             for severity, msg in issues:
@@ -234,6 +266,13 @@ def main():
         action="store_true",
         help="Exit non-zero on warnings as well as errors",
     )
+    parser.add_argument(
+        "--org",
+        metavar="FILE",
+        help="Path to org.yaml. Fields it supplies a default for (currently "
+             "owner) stop being required in front matter, matching what "
+             "docx-build --org already accepts.",
+    )
     args = parser.parse_args()
 
     root = Path(args.path).resolve()
@@ -241,7 +280,7 @@ def main():
         print(f"Error: path is not a directory: {root}", file=sys.stderr)
         sys.exit(1)
 
-    sys.exit(scan(root, strict=args.strict))
+    sys.exit(scan(root, strict=args.strict, org_defaults=_org_defaults(args.org)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The revision table printed whatever `author:` said. That value is wrong the moment somebody else edits the document, and nothing detects it. Git already records who changed what — the table now reads the fact instead of a copy of it.

## Resolution order

| Front matter | Behaviour |
|---|---|
| `revision_history:` list | **Curated, rendered unchanged.** A row reading *"Records the 2026-07-27 engineering decision"* is editorial content no commit subject reproduces. Git only fills a row whose `author` was left **blank** — so a curator can write version/date/description and let authorship resolve itself |
| `revision_history: auto` | Changelog generated from the file's commits, capped at 10 rows |
| neither | One row: author from git, everything else from front matter |

## Two decisions worth reviewing

**Authorship names contributors ranked by volume, not the last committer.** Attributing a document to whoever touched it last means a typo fix — or a repo-wide line-ending normalization — silently reassigns it, which is the inaccuracy this exists to remove. I hit exactly this while testing: the SAD's most recent commit was the eol pass, which would have credited the whole document to a formatting change. Capped at two names plus `+N`, because the column is 1.5 inches wide.

**The date stays with front matter** in the default mode. `date:` means last *substantive* revision — a human judgement — while git's newest commit includes typo fixes. Same reasoning as above. In `auto` mode the per-row date *is* the commit date, which is correct there because each row is a commit.

## Display names

A corporate address encodes the name: `first.last@example.org` → `First Last`. Addresses that carry no name — noreply forms, bot accounts, or a local part with no separator like `agambino@` — return nothing rather than a confident guess, and fall back to the git author name.

An `authors:` map in org.yaml reaches identities the pattern cannot, keyed by **email or git author name**. Name-keying matters for historical commits: one person who used several addresses over time is caught by a single name entry.

## Owner

Now defaults from `org.yaml` with a front-matter override. Owner names an accountable *team*, so one edit should set it everywhere; a document owned by another team overrides it locally.

## Safety

Every git failure falls back rather than raising — missing file, not a repo, git absent, timeout. A document must still render in a release tarball or a container that mounted only sources. Two tests cover exactly that.

## Verification

22 new tests, 130 pass overall. Verified end-to-end by rendering a real SAD with `--org` and reading the revision table and owner back out of the DOCX.