### PR TITLE
Auto-detect the org file, and stop crashing on a malformed one

### DIFF
--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -161,7 +161,10 @@ def _org_defaults(org_path: Path | str | None) -> set[str]:
     try:
         with open(org_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
-    except (OSError, yaml.YAMLError):
+    except (OSError, yaml.YAMLError, UnicodeDecodeError):
+        # UnicodeDecodeError is a ValueError, not an OSError, so it escapes
+        # the obvious catch: a latin-1 or binary file reaches this line and
+        # takes the linter down on the read rather than the parse.
         return set()
     if not isinstance(data, dict):
         return set()

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -119,18 +119,42 @@ def valid_statuses_for(doc_type: str) -> set[str]:
     return STANDARD_STATUSES
 
 
-def _org_defaults(org_path: str | None) -> set[str]:
+# Where an org file conventionally lives, relative to the scanned root.
+# Auto-detection exists so every entry point behaves the same without each
+# one remembering a flag: CI, pre-commit, the Dev Spaces task, and whatever
+# a developer types by hand. A flag that only some callers pass reproduces
+# the exact inconsistency this feature was added to remove.
+ORG_FILE_CANDIDATES = ["dac/org.yaml", "org.yaml", "vars/org.yaml"]
+
+
+def _find_org_file(root: Path, explicit: str | None) -> Path | None:
+    """Resolve the org file: an explicit path, else the conventional one."""
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_file() else None
+    for rel in ORG_FILE_CANDIDATES:
+        candidate = root / rel
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _org_defaults(org_path: Path | str | None) -> set[str]:
     """Fields the org file supplies a default for.
 
-    Read leniently: a malformed or unreadable org file means "no defaults",
-    not a crash. Its own validity is not this linter's business.
+    Read leniently: unreadable, malformed, or simply not a mapping means "no
+    defaults", not a crash. A YAML file that parses to a list or a scalar is
+    valid YAML and useless here, and this linter validates documents - the
+    org file's own shape is not its business to enforce.
     """
     if not org_path:
         return set()
     try:
         with open(org_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f) or {}
+            data = yaml.safe_load(f)
     except (OSError, yaml.YAMLError):
+        return set()
+    if not isinstance(data, dict):
         return set()
     org = data.get("org", data)
     if not isinstance(org, dict):
@@ -271,7 +295,8 @@ def main():
         metavar="FILE",
         help="Path to org.yaml. Fields it supplies a default for (currently "
              "owner) stop being required in front matter, matching what "
-             "docx-build --org already accepts.",
+             "docx-build --org already accepts. Auto-detected from "
+             + ", ".join(ORG_FILE_CANDIDATES) + " when omitted.",
     )
     args = parser.parse_args()
 
@@ -280,7 +305,12 @@ def main():
         print(f"Error: path is not a directory: {root}", file=sys.stderr)
         sys.exit(1)
 
-    sys.exit(scan(root, strict=args.strict, org_defaults=_org_defaults(args.org)))
+    org_file = _find_org_file(root, args.org)
+    if args.org and org_file is None:
+        print(f"Error: org file not found: {args.org}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(scan(root, strict=args.strict, org_defaults=_org_defaults(org_file)))
 
 
 if __name__ == "__main__":

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -128,10 +128,19 @@ ORG_FILE_CANDIDATES = ["dac/org.yaml", "org.yaml", "vars/org.yaml"]
 
 
 def _find_org_file(root: Path, explicit: str | None) -> Path | None:
-    """Resolve the org file: an explicit path, else the conventional one."""
+    """Resolve the org file: an explicit path, else the conventional one.
+
+    A relative --org is tried against the working directory first, because
+    that is what every CLI does with a path argument, and then against the
+    scanned root, because --org describes the tree being linted and a caller
+    standing elsewhere reasonably writes the path relative to it. Honouring
+    only one of the two reports "not found" for a file that is plainly there.
+    """
     if explicit:
-        p = Path(explicit)
-        return p if p.is_file() else None
+        for candidate in (Path(explicit), root / explicit):
+            if candidate.is_file():
+                return candidate
+        return None
     for rel in ORG_FILE_CANDIDATES:
         candidate = root / rel
         if candidate.is_file():

--- a/scripts/tests/test_lint_frontmatter_org.py
+++ b/scripts/tests/test_lint_frontmatter_org.py
@@ -1,0 +1,121 @@
+"""
+tests/test_lint_frontmatter_org.py — org-supplied front-matter defaults.
+
+`owner:` may be omitted from a document when org.yaml supplies it, because
+the builder resolves that default and CI rejecting the same document would
+put rendering and linting in disagreement.
+
+Two failure modes are pinned here:
+
+  * The org file is auto-detected, so every entry point behaves the same
+    without each one remembering a flag. A flag only some callers pass
+    reproduces the inconsistency this feature exists to remove.
+  * A malformed org file degrades to "no defaults" rather than crashing.
+    Valid YAML that parses to a list or a scalar is useless here but must
+    not take the linter down - it validates documents, not org files.
+
+Runs the script as a subprocess, so what is tested is what CI invokes.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "lint-frontmatter.py"
+
+DOC_WITHOUT_OWNER = """---
+title: "Test Document"
+doc_type: "reference"
+domain: "automation"
+department: "Infrastructure & Operations"
+status: "Draft"
+version: "0.1"
+date: "2026-08-05"
+author: "Alex Gambino"
+---
+
+# Test Document
+
+This reference exists to exercise owner defaulting.
+"""
+
+
+def _run(root: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--path", str(root), *extra],
+        capture_output=True, text=True,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "doc.md").write_text(DOC_WITHOUT_OWNER, encoding="utf-8")
+    (tmp_path / "dac").mkdir()
+    return tmp_path
+
+
+def _write_org(repo: Path, text: str) -> None:
+    (repo / "dac" / "org.yaml").write_text(text, encoding="utf-8")
+
+
+def test_owner_required_when_no_org_file(repo):
+    result = _run(repo)
+    assert result.returncode == 1
+    assert "owner" in result.stdout
+
+
+def test_org_file_is_auto_detected(repo):
+    # No --org flag. The Dev Spaces task, the README command, and a developer
+    # typing it by hand all invoke the script this way.
+    _write_org(repo, 'org:\n  owner: "Some Team"\n')
+    assert _run(repo).returncode == 0
+
+
+def test_flat_org_file_without_org_key(repo):
+    _write_org(repo, 'owner: "Some Team"\n')
+    assert _run(repo).returncode == 0
+
+
+def test_blank_owner_is_not_a_default(repo):
+    # Present but empty supplies nothing, so the document is still missing it.
+    _write_org(repo, 'org:\n  owner: ""\n')
+    assert _run(repo).returncode == 1
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [
+        ("list", "- one\n- two\n"),
+        ("scalar", "just-a-string\n"),
+        ("empty", ""),
+        ("malformed", "org:\n  owner: [unclosed\n"),
+    ],
+)
+def test_unusable_org_file_degrades_rather_than_crashing(repo, label, content):
+    _write_org(repo, content)
+    result = _run(repo)
+    # Exit 1 is the document failing validation, which is correct - no default
+    # was available. Exit 2 or a traceback would be the linter itself dying.
+    assert result.returncode == 1, f"{label}: {result.stderr}"
+    assert "Traceback" not in result.stderr, f"{label}: linter crashed"
+
+
+def test_explicit_org_path_overrides_detection(repo):
+    _write_org(repo, 'org:\n  owner: ""\n')          # would not satisfy it
+    other = repo / "elsewhere.yaml"
+    other.write_text('org:\n  owner: "Other Team"\n', encoding="utf-8")
+    assert _run(repo, "--org", str(other)).returncode == 0
+
+
+def test_missing_explicit_org_path_is_an_error_not_a_shrug(repo):
+    # Silently ignoring a path the caller asked for would hide a typo in CI
+    # config as a lint pass. Exit 1 matches this script's existing convention
+    # for usage errors (see the not-a-directory check); stderr is what
+    # distinguishes a config mistake from a document failure.
+    result = _run(repo, "--org", str(repo / "nope.yaml"))
+    assert result.returncode != 0
+    assert "not found" in result.stderr
+    assert "Checked" not in result.stdout, "should fail before scanning"

--- a/scripts/tests/test_lint_frontmatter_org.py
+++ b/scripts/tests/test_lint_frontmatter_org.py
@@ -110,6 +110,25 @@ def test_explicit_org_path_overrides_detection(repo):
     assert _run(repo, "--org", str(other)).returncode == 0
 
 
+def test_relative_org_path_resolves_against_the_scanned_root(repo, tmp_path):
+    """--org may be written relative to the tree being linted.
+
+    Running the linter from somewhere other than the scanned root is normal
+    (a pre-commit hook, a CI step with a working directory set elsewhere).
+    Resolving a relative --org only against the process CWD reports "not
+    found" for a file sitting exactly where the caller said it was.
+    """
+    _write_org(repo, 'org:\n  owner: "Some Team"\n')
+    elsewhere = tmp_path.parent / "cwd-elsewhere"
+    elsewhere.mkdir(exist_ok=True)
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--path", str(repo),
+         "--org", "dac/org.yaml"],
+        capture_output=True, text=True, cwd=str(elsewhere),
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_missing_explicit_org_path_is_an_error_not_a_shrug(repo):
     # Silently ignoring a path the caller asked for would hide a typo in CI
     # config as a lint pass. Exit 1 matches this script's existing convention

--- a/scripts/tests/test_lint_frontmatter_org.py
+++ b/scripts/tests/test_lint_frontmatter_org.py
@@ -110,6 +110,19 @@ def test_explicit_org_path_overrides_detection(repo):
     assert _run(repo, "--org", str(other)).returncode == 0
 
 
+def test_undecodable_org_file_degrades_rather_than_crashing(repo):
+    """A file that is not UTF-8 at all.
+
+    UnicodeDecodeError is a ValueError, not an OSError, so it escapes the
+    obvious catch and would take the linter down on the READ rather than the
+    parse - a failure mode the malformed-YAML cases above never reach.
+    """
+    (repo / "dac" / "org.yaml").write_bytes(bytes([0xFF, 0xFE, 0x00, 0x80, 0x81]))
+    result = _run(repo)
+    assert result.returncode == 1, result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_relative_org_path_resolves_against_the_scanned_root(repo, tmp_path):
     """--org may be written relative to the tree being linted.
 


### PR DESCRIPTION
Two findings from review of [architecture-docs#184](https://github.com/KhalilGibrotha/architecture-docs/pull/184), where this script's `--org` flag was first wired up. The second suggested the better fix for the first.

## Copilot: crash on a non-mapping org file

`_org_defaults` called `.get()` on whatever `yaml.safe_load` returned. A file that is valid YAML but not a mapping — a list, a scalar — raised `AttributeError` and took the linter down, directly contradicting the function's own *"read leniently"* docstring.

Now degrades to "no defaults" for any shape it cannot use. This linter validates **documents**; the org file's own shape is not its business to enforce.

## Codex: entry points had to stay in sync

`--org` had to be passed everywhere or the callers disagreed. In architecture-docs that meant **six** places: CI, pre-commit, the Dev Spaces task, the README command, the PR template, and CLAUDE.md.

The failure that creates is the same one this feature was added to remove — a developer running the Dev Spaces task gets rejected for a document CI accepts. Adding the flag six times just relocates the problem, so I took Codex's alternative and made detection automatic.

The org file is found at `dac/org.yaml`, `org.yaml`, or `vars/org.yaml` relative to the scanned root. `--org` still overrides for a non-standard layout.

One deliberate strictness: an explicit `--org` path that does not exist is now an **error**, not a silent fallback to detection. A typo in CI config should not read as a lint pass.

## Tests

Ten new, covering auto-detection, the flat org format (no `org:` key), a blank value supplying nothing, all four unusable-file shapes (list, scalar, empty, malformed), explicit override, and the missing-path error. They run the script as a subprocess, so what is tested is what CI invokes. 141 pass overall.