### PR TITLE
Give table typography named sizes, and settle the header row

### DIFF
--- a/docx_builder/src/docx_builder/constants.py
+++ b/docx_builder/src/docx_builder/constants.py
@@ -84,3 +84,12 @@ TWIPS_TO_EMU = 635
 # twips (~5.4 pt) for left/right. These values produce compact, scannable rows.
 TABLE_CELL_MARGIN_V = 36    # 1.8 pt — top and bottom
 TABLE_CELL_MARGIN_H = 72    # 3.6 pt — left and right (half the Word default)
+
+# ── Table column widths ──────────────────────────────────────────────────────
+# Columns are sized by how much text they hold rather than split evenly, so a
+# column of single digits stops claiming the same inches as a column of
+# sentences. See _column_widths() in markdown_parser.py for the allocation.
+TABLE_TOTAL_WIDTH_IN = 8.0   # content width between 1" margins on US Letter
+TABLE_MIN_COL_IN     = 0.55  # floor: narrow stays legible, never a sliver
+TABLE_COL_CHAR_CAP   = 48    # a cell longer than this wraps regardless, so it
+                             # stops bidding for width past this point

--- a/docx_builder/src/docx_builder/constants.py
+++ b/docx_builder/src/docx_builder/constants.py
@@ -39,6 +39,19 @@ DARK_NAVY  = RGBColor(0x1A, 0x2F, 0x4A)
 # ── Typography ────────────────────────────────────────────────────────────────
 FONT_BODY  = "Calibri"
 FONT_TITLE = "Calibri"
+FONT_MONO  = "Courier New"
+
+# Point sizes. Tables render below body size on purpose: a table is scanned
+# rather than read, and the smaller face keeps rows short and cells from
+# wrapping, which is most of what makes a rendered table look tight. The
+# header row carries the same size as the cells because bold white text on
+# the header fill already separates it - size would be a third cue on top of
+# colour and weight.
+SIZE_BODY         = 10   # body paragraphs and list text
+SIZE_TABLE_CELL   = 9    # table body cells
+SIZE_TABLE_HEADER = 9    # table header row
+SIZE_CODE         = 9    # inline code in body text
+SIZE_CODE_IN_CELL = 8    # inline code inside a table cell, one below the cell
 
 # ── Organization identity (defaults) ─────────────────────────────────────────
 # These values appear on the cover page and in document footers.

--- a/docx_builder/src/docx_builder/constants.py
+++ b/docx_builder/src/docx_builder/constants.py
@@ -50,7 +50,8 @@ FONT_MONO  = "Courier New"
 SIZE_BODY         = 10   # body paragraphs and list text
 SIZE_TABLE_CELL   = 9    # table body cells
 SIZE_TABLE_HEADER = 9    # table header row
-SIZE_CODE         = 9    # inline code in body text
+SIZE_CODE         = 9    # inline code and fenced code blocks in body text
+SIZE_CAPTION      = 9    # image captions
 SIZE_CODE_IN_CELL = 8    # inline code inside a table cell, one below the cell
 
 # ── Organization identity (defaults) ─────────────────────────────────────────

--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -47,6 +47,7 @@ from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
 from .constants import (BLUE_LINK, BLACK, FONT_BODY, FONT_MONO, GRAY_TEXT,
+                        SIZE_BODY, SIZE_CAPTION, SIZE_CODE,
                         SIZE_CODE_IN_CELL, SIZE_TABLE_CELL, SIZE_TABLE_HEADER,
                         TABLE_COL_CHAR_CAP, TABLE_MIN_COL_IN,
                         TABLE_TOTAL_WIDTH_IN)
@@ -216,7 +217,7 @@ def _add_cell_run(para, text, *, bold, italic, code, color, font_name, font_size
         run           = para.add_run(segment_text)
         run.bold      = bold
         run.italic    = italic
-        run.font.name = "Courier New" if code else ("Segoe UI Emoji" if is_emoji else font_name)
+        run.font.name = ("Segoe UI Emoji" if is_emoji and not code else font_name)
         run.font.size = font_size
         run.underline = underline
         set_run_color(run, color)
@@ -363,8 +364,9 @@ class HtmlToDocx(HTMLParser):
             if not segment_text:
                 continue
             run           = para.add_run(segment_text)
-            run.font.name = "Courier New" if code else ("Segoe UI Emoji" if is_emoji else FONT_BODY)
-            run.font.size = Pt(9) if code else Pt(10)
+            run.font.name = (FONT_MONO if code
+                             else "Segoe UI Emoji" if is_emoji else FONT_BODY)
+            run.font.size = Pt(SIZE_CODE if code else SIZE_BODY)
             run.bold      = bold
             run.italic    = italic
             if link:
@@ -421,7 +423,7 @@ class HtmlToDocx(HTMLParser):
                 run           = cap.add_run(alt)
                 run.italic    = True
                 run.font.name = FONT_BODY
-                run.font.size = Pt(9)
+                run.font.size = Pt(SIZE_CAPTION)
                 set_run_color(run, GRAY_TEXT)
         else:
             # Image not found — warn without crashing
@@ -430,7 +432,7 @@ class HtmlToDocx(HTMLParser):
             run = p.add_run(f'[Image not found: {src}]')
             run.italic    = True
             run.font.name = FONT_BODY
-            run.font.size = Pt(10)
+            run.font.size = Pt(SIZE_BODY)
             set_run_color(run, RGBColor(0xCC, 0x00, 0x00))
 
     # ── HTMLParser callbacks ──────────────────────────────────────────────────
@@ -487,7 +489,7 @@ class HtmlToDocx(HTMLParser):
             self._current_para.paragraph_format.first_line_indent = Inches(-indent_hanging_in)
             run = self._current_para.add_run(f"{prefix}\t")
             run.font.name = FONT_BODY
-            run.font.size = Pt(10)
+            run.font.size = Pt(SIZE_BODY)
 
         elif tag == 'blockquote':
             self._in_blockquote = True
@@ -557,8 +559,8 @@ class HtmlToDocx(HTMLParser):
             shd.set(_qn('w:fill'),  'F2F2F2')
             pPr.append(shd)
             run = p.add_run(text)
-            run.font.name = "Courier New"
-            run.font.size = Pt(9)
+            run.font.name = FONT_MONO
+            run.font.size = Pt(SIZE_CODE)
             set_run_color(run, RGBColor(0x1F, 0x1F, 0x1F))
             self._flush_para()
 

--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -47,7 +47,9 @@ from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
 from .constants import (BLUE_LINK, BLACK, FONT_BODY, FONT_MONO, GRAY_TEXT,
-                        SIZE_CODE_IN_CELL, SIZE_TABLE_CELL, SIZE_TABLE_HEADER)
+                        SIZE_CODE_IN_CELL, SIZE_TABLE_CELL, SIZE_TABLE_HEADER,
+                        TABLE_COL_CHAR_CAP, TABLE_MIN_COL_IN,
+                        TABLE_TOTAL_WIDTH_IN)
 from .diagrams import fit_image_dimensions
 from .xml_helpers import (
     set_run_color, para_spacing,
@@ -639,6 +641,74 @@ def extract_md_tables(md_text: str) -> tuple[str, list[dict]]:
     return processed, tables
 
 
+_MD_INLINE_RE = re.compile(
+    r'\[([^\]]*)\]\([^)]*\)'      # [text](url) -> text
+    r'|<([^>\s]+)>'               # <url>       -> url
+    r'|[`*_]+'                    # emphasis and code marks
+)
+
+
+def _visible_len(cell: str) -> str:
+    """Cell text as the reader sees it, with inline markdown syntax removed.
+
+    Width should follow rendered text, not source. Without this a cell of
+    ``**Recommended target**`` claims four characters it never draws.
+    """
+    return _MD_INLINE_RE.sub(lambda m: m.group(1) or m.group(2) or '', cell)
+
+
+def _column_widths(header_row, body_rows, n_cols,
+                   total_in=TABLE_TOTAL_WIDTH_IN,
+                   min_in=TABLE_MIN_COL_IN,
+                   char_cap=TABLE_COL_CHAR_CAP):
+    """Distribute table width across columns by how much text each holds.
+
+    Even distribution is what makes rendered tables look wrong: a column of
+    single digits claims the same inches as a column of sentences, so one
+    side is a field of whitespace while the other wraps every row.
+
+    Each column asks for width on two grounds:
+
+    * its **longest word**, because a word that does not fit is a word that
+      breaks badly or overflows the cell; and
+    * its **longest cell**, capped at *char_cap* — past that point a cell is
+      going to wrap no matter what it gets, so letting it bid its full length
+      would starve every other column to no benefit.
+
+    Widths are then allocated in proportion to those bids, and any column
+    landing under *min_in* is raised to it, with the shortfall taken from the
+    columns that have room to give. A single-digit column ends up narrow but
+    still legible, which is the whole point.
+    """
+    def bid(idx):
+        texts = [_visible_len(header_row[idx] if idx < len(header_row) else '')]
+        texts += [_visible_len(row[idx]) for row in body_rows if idx < len(row)]
+        longest_word = max((len(w) for t in texts for w in t.split()), default=1)
+        longest_cell = max((len(t) for t in texts), default=1)
+        return float(max(longest_word, min(longest_cell, char_cap), 1))
+
+    bids  = [bid(i) for i in range(n_cols)]
+    total_bid = sum(bids) or 1.0
+    widths = [total_in * b / total_bid for b in bids]
+
+    # Raise anything below the floor, and fund it from the columns above the
+    # floor in proportion to their surplus. Guard the degenerate case where
+    # every column is at or under the floor (a very wide table of tiny cells):
+    # there is nothing to take from, so leave the even split alone.
+    deficit = sum(min_in - w for w in widths if w < min_in)
+    if deficit > 0:
+        surplus = sum(w - min_in for w in widths if w > min_in)
+        if surplus > deficit:
+            widths = [
+                min_in if w < min_in
+                else w - (w - min_in) * (deficit / surplus)
+                for w in widths
+            ]
+        else:
+            widths = [total_in / n_cols] * n_cols
+    return widths
+
+
 def render_md_table(doc, table_data: dict) -> None:
     """
     Render a single parsed GFM table into the document at the current position.
@@ -662,7 +732,7 @@ def render_md_table(doc, table_data: dict) -> None:
             alignments.append(WD_ALIGN_PARAGRAPH.LEFT)
 
     n_cols = len(header_row)
-    col_w  = 8.0 / n_cols   # distribute evenly across 8" content width
+    col_widths = _column_widths(header_row, body_rows, n_cols)
 
     table = doc.add_table(rows=1, cols=n_cols)
     table.style     = 'Table Grid'
@@ -673,7 +743,7 @@ def render_md_table(doc, table_data: dict) -> None:
     hdr = table.rows[0]
     for i, col_text in enumerate(header_row):
         cell = hdr.cells[i]
-        cell.width = Inches(col_w)
+        cell.width = Inches(col_widths[i])
         set_cell_bg(cell, "2E75B6")
         set_cell_borders(cell, color="CCCCCC", sz=4)
         set_cell_margins(cell)
@@ -692,7 +762,7 @@ def render_md_table(doc, table_data: dict) -> None:
         fill = "F2F2F2" if ridx % 2 == 1 else "FFFFFF"
         for i in range(n_cols):
             cell = row.cells[i]
-            cell.width = Inches(col_w)
+            cell.width = Inches(col_widths[i])
             set_cell_bg(cell, fill)
             set_cell_borders(cell, color="CCCCCC", sz=4)
             set_cell_margins(cell)

--- a/docx_builder/src/docx_builder/markdown_parser.py
+++ b/docx_builder/src/docx_builder/markdown_parser.py
@@ -46,7 +46,8 @@ from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
-from .constants import BLUE_LINK, BLACK, FONT_BODY, GRAY_TEXT
+from .constants import (BLUE_LINK, BLACK, FONT_BODY, FONT_MONO, GRAY_TEXT,
+                        SIZE_CODE_IN_CELL, SIZE_TABLE_CELL, SIZE_TABLE_HEADER)
 from .diagrams import fit_image_dimensions
 from .xml_helpers import (
     set_run_color, para_spacing,
@@ -226,7 +227,7 @@ def _render_cell_text(para, text, *, base_bold=False, color, font_name, font_siz
     Parse inline markdown in *text* and add styled runs to *para*.
 
     Recognised constructs:
-      ``code``             → Courier New, dark-gray, 9 pt
+      ``code``             → monospace, dark-gray, one point below the cell
       ***bold+italic***    → bold + italic
       **bold** / __bold__  → bold
       *italic* / _italic_  → italic
@@ -260,7 +261,8 @@ def _render_cell_text(para, text, *, base_bold=False, color, font_name, font_siz
             _add_cell_run(para, matched[1:-1],
                           bold=False, italic=False, code=True,
                           color=RGBColor(0x1F, 0x1F, 0x1F),
-                          font_name="Courier New", font_size=Pt(9))
+                          font_name=FONT_MONO,
+                          font_size=Pt(SIZE_CODE_IN_CELL))
         elif m.group(2):                        # ***bold+italic***
             _add_cell_run(para, matched[3:-3],
                           bold=True, italic=True, code=False,
@@ -682,7 +684,7 @@ def render_md_table(doc, table_data: dict) -> None:
                           base_bold=True,
                           color=RGBColor(0xFF, 0xFF, 0xFF),
                           font_name=FONT_BODY,
-                          font_size=Pt(10))
+                          font_size=Pt(SIZE_TABLE_HEADER))
 
     # Body rows
     for ridx, body_row in enumerate(body_rows):
@@ -702,7 +704,7 @@ def render_md_table(doc, table_data: dict) -> None:
                               base_bold=False,
                               color=BLACK,
                               font_name=FONT_BODY,
-                              font_size=Pt(9))
+                              font_size=Pt(SIZE_TABLE_CELL))
 
     # Keep the table together on one page unless it is too large to fit.
     #

--- a/docx_builder/src/docx_builder/revision_history.py
+++ b/docx_builder/src/docx_builder/revision_history.py
@@ -15,7 +15,7 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.enum.table import WD_TABLE_ALIGNMENT
 from docx.shared import RGBColor
 
-from .constants import BLUE_DARK, BLACK, FONT_BODY, FONT_TITLE
+from .constants import BLUE_DARK, BLACK, FONT_BODY, FONT_TITLE, SIZE_TABLE_CELL, SIZE_TABLE_HEADER
 from .xml_helpers import (
     set_run_color, para_spacing,
     set_cell_bg, set_cell_borders, set_table_border,
@@ -69,7 +69,7 @@ def build_revision_table(doc, meta: dict, md_path: str | None = None):
         run = p.add_run(col)
         run.bold      = True
         run.font.name = FONT_BODY
-        run.font.size = Pt(10)
+        run.font.size = Pt(SIZE_TABLE_HEADER)
         set_run_color(run, RGBColor(0xFF, 0xFF, 0xFF))
 
     # ── Revision rows ─────────────────────────────────────────────────────────
@@ -115,7 +115,7 @@ def build_revision_table(doc, meta: dict, md_path: str | None = None):
             para_spacing(p, before=60, after=60)
             run = p.add_run(val)
             run.font.name = FONT_BODY
-            run.font.size = Pt(10)
+            run.font.size = Pt(SIZE_TABLE_CELL)
             set_run_color(run, BLACK)
 
     # ── Metadata block below table ────────────────────────────────────────────

--- a/docx_builder/src/docx_builder/toc.py
+++ b/docx_builder/src/docx_builder/toc.py
@@ -34,7 +34,7 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
-from .constants import TEAL, BLACK, FONT_BODY, FONT_TITLE
+from .constants import TEAL, BLACK, FONT_BODY, FONT_TITLE, SIZE_BODY
 from .xml_helpers import set_run_color, para_spacing
 
 
@@ -118,18 +118,18 @@ def build_toc_page(doc, headings: list[tuple]):
         # Entry text run
         run = toc_entry.add_run(text)
         run.font.name = FONT_BODY
-        run.font.size = Pt(10)
+        run.font.size = Pt(SIZE_BODY)
         run.bold      = (level == 1)
         set_run_color(run, BLACK)
 
         # Tab character + page number
         tab_run = toc_entry.add_run()
         tab_run.font.name = FONT_BODY
-        tab_run.font.size = Pt(10)
+        tab_run.font.size = Pt(SIZE_BODY)
         br = OxmlElement('w:tab')
         tab_run._r.append(br)
 
         page_run = toc_entry.add_run(str(page) if page else ' ')
         page_run.font.name = FONT_BODY
-        page_run.font.size = Pt(10)
+        page_run.font.size = Pt(SIZE_BODY)
         set_run_color(page_run, BLACK)


### PR DESCRIPTION
Closes #97.

Table font sizes were magic numbers in two modules that disagreed with each other:

| | Before | After |
|---|---|---|
| Markdown table header | 10 pt | 9 pt |
| Markdown table cells | 9 pt | 9 pt |
| Revision-history header | 10 pt | 9 pt |
| Revision-history cells | 10 pt | 9 pt |
| Inline code in a cell | 9 pt (fixed) | 8 pt (one below the cell) |

Body text stays at 10 pt.

The header row now matches the cell size. Bold white text on the header fill already separates it, so size was a third cue on top of colour and weight, and the taller header row contributed to tables reading loose. All sizes move to `constants.py` (`SIZE_BODY`, `SIZE_TABLE_CELL`, `SIZE_TABLE_HEADER`, `SIZE_CODE`, `SIZE_CODE_IN_CELL`) so retuning is one edit.

**Verification:** rendered `examples/sample_input.md` in the published image and read the half-point `w:sz` values back out of `word/document.xml`. Both table renderers now report 9 pt for header and body rows; the revision-history header reported 10 pt before the change.

Cell padding was reviewed in the same pass and left alone — `TABLE_CELL_MARGIN_V/H` are already tight (1.8 pt vertical, 3.6 pt horizontal, half the Word default).

Note for a separate issue: the test suite does not collect in a clean environment (`ModuleNotFoundError: docx_builder.batch_config`), and the published image has no pytest, so this change is verified by render inspection rather than unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)