### PR TITLE
Accept Superseded on the decision status track

### DIFF
--- a/docx_builder/src/docx_builder/batch_scanner.py
+++ b/docx_builder/src/docx_builder/batch_scanner.py
@@ -35,7 +35,7 @@ INFORMATIONAL_REQUIRED = ('title', 'status', 'version')   # doc_type exempt
 
 VALID_STATUSES = frozenset({
     'Draft', 'In Review', 'Accepted', 'Rejected',
-    'Retired', 'Proposed', 'Informational',
+    'Retired', 'Proposed', 'Informational', 'Superseded',
 })
 
 

--- a/docx_builder/tests/test_batch_scanner.py
+++ b/docx_builder/tests/test_batch_scanner.py
@@ -116,3 +116,47 @@ def test_note_spans_two_lines(tmp_path):
     config = _repo(tmp_path, {"docs/notes.md": NO_FRONT_MATTER})
     _, warnings = scan(config)
     assert "\n" in _notes(warnings)[0]
+
+
+# ── Allowed-status list ──────────────────────────────────────────────────────
+#
+# A status missing from VALID_STATUSES does not fail the build - the document
+# is excluded with a warning, which is easy to miss in batch output. These
+# pin the boundary so an enum change is deliberate in both directions.
+
+DOC_SUPERSEDED = """
+    ---
+    title: "Old Decision"
+    doc_type: "adr"
+    status: "Superseded"
+    version: "1.0"
+    ---
+
+    # Old Decision
+    """
+
+DOC_UNKNOWN_STATUS = """
+    ---
+    title: "Odd"
+    doc_type: "overview"
+    status: "Living"
+    version: "0.1"
+    ---
+
+    # Odd
+    """
+
+
+def test_superseded_is_a_valid_status(tmp_path):
+    config = _repo(tmp_path, {"docs/old-decision.md": DOC_SUPERSEDED})
+    docs, warnings = scan(config)
+    assert [d.title for d in docs] == ["Old Decision"]
+    assert not [w for w in warnings if "unknown status" in w]
+
+
+def test_unknown_status_excludes_with_a_warning_not_a_failure(tmp_path):
+    config = _repo(tmp_path, {"docs/odd.md": DOC_UNKNOWN_STATUS,
+                              "docs/ok.md": DOC_VALID})
+    docs, warnings = scan(config)
+    assert [d.title for d in docs] == ["Current"]
+    assert any("unknown status 'Living'" in w for w in warnings)

--- a/scripts/lint-frontmatter.py
+++ b/scripts/lint-frontmatter.py
@@ -48,7 +48,7 @@ APPROVED_DOC_TYPES = {
 
 # Status tracks
 STANDARD_STATUSES   = {"Draft", "In Review", "Accepted", "Retired"}
-DECISION_STATUSES   = {"Proposed", "Accepted", "Rejected", "Retired"}
+DECISION_STATUSES   = {"Proposed", "Accepted", "Rejected", "Retired", "Superseded"}
 INFORMATIONAL_STATUSES = {"Informational"}
 
 # Map doc_type to its status track


### PR DESCRIPTION
Adds `Superseded` to the two status enforcement points, per the artifact-lifecycle ADR in the consuming architecture repo: decision records freeze at acceptance and are only ever superseded, with the old record staying renderable.

- `scripts/lint-frontmatter.py` — decision track gains the value.
- `docx_builder/batch_scanner.py` — global `VALID_STATUSES` gains it. An unknown status excludes the document **with a warning but without failing the build** — the build succeeds while the document goes missing from output, which is why this releases before any document carries the value. (Earlier wording said "silently skips"; review correctly noted a warning is emitted.)
- Two boundary tests: `Superseded` scans cleanly; an unknown status excludes with a warning while the rest of the build proceeds.

168 tests pass in the v1.1.0 image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)