### PR TITLE
Revert the version bump that bypassed the pull-request rule

### DIFF
--- a/docx_builder/pyproject.toml
+++ b/docx_builder/pyproject.toml
@@ -4,12 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docx-builder"
-# Tracks the repository release it ships in, because the image is the product
-# and "which docx_builder is this?" should have one answer. It sat at 1.0.0
-# through the whole of v1.1.0, whose headline change was table rendering
-# inside this package — so the number was answering the question wrongly
-# rather than declining to answer it.
-version = "1.2.0"
+version = "1.0.0"
 description = "Converts Markdown + YAML front matter to styled DOCX with cover page, TOC, and auto-numbered headings"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Reverts f9e9ac55, which I pushed straight to `main`. The push reported:

```
remote: Bypassed rule violations for refs/heads/main:
remote: - Changes must be made through a pull request.
```

It went through only because the pushing account is an admin. Every other change to this repository today went through review — #98, #100, #104 — and this one should have too.

**The content was not the problem.** The bump is correct and tested: `pyproject` parses, the package installs and imports, 168 tests pass. This revert is about how it arrived, not what it said.

The same change comes back immediately in a follow-up PR, so `main` ends up in the intended state with the bump having been reviewed. Tagging v1.2.0 waits until that lands, because tagging this commit would have blessed the bypass.