### PR TITLE
Bump the package version to the release it ships in

### DIFF
--- a/docx_builder/pyproject.toml
+++ b/docx_builder/pyproject.toml
@@ -4,7 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docx-builder"
-version = "1.0.0"
+# Tracks the repository release it ships in, because the image is the product
+# and "which docx_builder is this?" should have one answer. It sat at 1.0.0
+# through the whole of v1.1.0, whose headline change was table rendering
+# inside this package - so the number was answering the question wrongly
+# rather than declining to answer it.
+version = "1.2.0"
 description = "Converts Markdown + YAML front matter to styled DOCX with cover page, TOC, and auto-numbered headings"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Re-lands the change #105 reverted, through review this time.

`docx-builder` has reported `version = "1.0.0"` on every image since v1.0.0 — including the whole of v1.1.0, whose headline change was table rendering *inside this package*. The number was not declining to answer "which docx_builder is this?"; it was answering wrongly.

Setting it to `1.2.0` ties it to the release it ships in, which is the least surprising answer for a repository where the image is the product.

## Verified

- `pyproject` parses and reports `docx-builder 1.2.0`
- the package installs editable and imports
- 168 tests pass from the repository root

## Why this exists as two PRs

The same change reached `main` earlier as a direct push, which bypassed this repository's pull-request rule and succeeded only because the pushing account is an admin. #105 reverted it. This PR brings it back the documented way, so `main` ends in the intended state with the change reviewed rather than waved through.

v1.2.0 gets tagged once this lands.