### PR TITLE
Bust the cached dnf upgrade layer so the CVE fix is applied

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -29,6 +29,13 @@ RUN dnf config-manager --set-disabled rhel-9-for-x86_64-appstream-rpms \
 # build time; the Trivy gate below verifies it worked. If the gate ever fails
 # on a package this upgrade should have fixed, the cached layer is stale —
 # re-run the workflow with the cache invalidated (or bump this comment).
+#
+# Cache-bust 2026-08-13: the v1.2.0 tag build failed the Trivy gate on
+# CVE-2026-11940 (python3, tarfile extraction filter bypass), fixable to
+# 3.9.25-7.el9_8.3. Worth recording why bumping the base would NOT have
+# fixed it: the current ubi9/python-312 still ships -7.el9_8.2, and the
+# fixed RPM comes from ubi-9-baseos-rpms at build time. This layer was the
+# only thing that could pick it up, and it was cached.
 RUN dnf upgrade -y --nodocs && dnf clean all
 
 # ── System dependencies for Chromium (Puppeteer) and Pandoc ──────────────────


### PR DESCRIPTION
The v1.2.0 tag build failed the Trivy gate:

```
Total: 2 (HIGH: 2, CRITICAL: 0)
python3  CVE-2026-11940  HIGH  fixed  3.9.25-7.el9_8.2 → 3.9.25-7.el9_8.3
         python: cpython: CPython: tarfile extraction filter bypass
```

This is the exact case the layer's own comment predicts:

> If the gate ever fails on a package this upgrade should have fixed, the cached layer is stale — re-run the workflow with the cache invalidated (or bump this comment).

`cache-from: type=gha` had been serving the `dnf upgrade` layer from cache, so it never re-ran and the image kept the vulnerable RPM.

## Why bumping the base would not have fixed it

The obvious move — bump the pinned digest, since the comment above it says Dependabot does exactly that — does not work here. I checked the current `ubi9/python-312` before assuming:

```
in the latest base:   python3-3.9.25-7.el9_8.2     <- still vulnerable
available from repo:  python3-3.9.25-7.el9_8.3     <- the fix (ubi-9-baseos-rpms)
```

The base image tag lags the errata, which is precisely why this upgrade layer exists. It is the only thing that can apply the fix, and it was cached. A digest bump would have changed the base, busted the cache as a side effect, and looked like it worked for the wrong reason.

Editing the comment changes the instruction text, so the layer re-executes and `dnf upgrade` picks up `-7.el9_8.3`.

## What happens next

`main` builds and republishes `latest`. Then v1.2.0 gets re-tagged onto the resulting commit, Release QA dispatched for it, and the tag pushed — the tag currently points at a commit whose build failed this gate, and no `v1.2.0` image was ever published (`manifest unknown`), so moving it reaches no consumer.