### PR TITLE
Put the cache-bust token inside the RUN, where it can actually work

### DIFF
--- a/.devcontainer/Dockerfile.devspaces
+++ b/.devcontainer/Dockerfile.devspaces
@@ -28,15 +28,22 @@ RUN dnf config-manager --set-disabled rhel-9-for-x86_64-appstream-rpms \
 # keep a stale base for weeks. Upgrading here picks up every fixable CVE at
 # build time; the Trivy gate below verifies it worked. If the gate ever fails
 # on a package this upgrade should have fixed, the cached layer is stale —
-# re-run the workflow with the cache invalidated (or bump this comment).
+# re-run the workflow with the cache invalidated, or bump CACHE_BUST below.
 #
-# Cache-bust 2026-08-13: the v1.2.0 tag build failed the Trivy gate on
-# CVE-2026-11940 (python3, tarfile extraction filter bypass), fixable to
-# 3.9.25-7.el9_8.3. Worth recording why bumping the base would NOT have
-# fixed it: the current ubi9/python-312 still ships -7.el9_8.2, and the
-# fixed RPM comes from ubi-9-baseos-rpms at build time. This layer was the
-# only thing that could pick it up, and it was cached.
-RUN dnf upgrade -y --nodocs && dnf clean all
+# CACHE_BUST is INSIDE the RUN instruction on purpose. An earlier version of
+# this comment said "bump this comment", which cannot work: the Dockerfile
+# parser strips `#` lines before computing the layer cache key, so editing
+# them changes nothing and the stale layer is served again. Only the
+# instruction text counts, so the date has to live in the command.
+#
+# 2026-08-13: bumped because the v1.2.0 tag build failed the Trivy gate on
+# CVE-2026-11940 (python3, tarfile extraction filter bypass). Note that
+# bumping the pinned base would NOT have fixed it — the current
+# ubi9/python-312 still ships -7.el9_8.2, and -7.el9_8.3 comes from
+# ubi-9-baseos-rpms at build time. This layer is the only thing that applies
+# it.
+RUN CACHE_BUST=2026-08-13 && echo "cache bust: $CACHE_BUST" \
+    && dnf upgrade -y --nodocs && dnf clean all
 
 # ── System dependencies for Chromium (Puppeteer) and Pandoc ──────────────────
 RUN dnf install -y --nodocs \


### PR DESCRIPTION
#107 did exactly what the layer's comment prescribed — "bump this comment" — and the build failed again with the identical finding:

```
Total: 2 (HIGH: 2, CRITICAL: 0)
python3  CVE-2026-11940  HIGH  fixed  3.9.25-7.el9_8.2 → 3.9.25-7.el9_8.3
```

**The documented remedy cannot work.** The Dockerfile parser strips `#` comment lines before computing the layer cache key. Editing a comment changes nothing the cache can see, so the stale `dnf upgrade` layer is served again and the vulnerable RPM survives. Only the instruction text participates in the cache key.

So the token has to be in the command:

```dockerfile
RUN CACHE_BUST=2026-08-13 && echo "cache bust: $CACHE_BUST" \
    && dnf upgrade -y --nodocs && dnf clean all
```

Bumping that date now changes the instruction and forces the layer to re-execute. The comment above it says why, so the next person does not spend a build cycle on the advice that just failed twice.

## The chain, for the record

Three things had to be true for this CVE to survive, and only the third was actionable:

1. The base image tag lags the errata — `ubi9/python-312:latest` still ships `-7.el9_8.2`, so a digest bump would not have fixed it.
2. `-7.el9_8.3` is available from `ubi-9-baseos-rpms` at build time, so the `dnf upgrade` layer is the only thing that can apply it.
3. That layer was cached, and the documented way to bust it was ineffective.